### PR TITLE
Add example questions page

### DIFF
--- a/src/main/java/org/chemvantage/ExampleQuestions.java
+++ b/src/main/java/org/chemvantage/ExampleQuestions.java
@@ -35,6 +35,28 @@ public class ExampleQuestions extends HttpServlet {
 	private static final int DEFAULT_QUESTION_COUNT = 3;
 	private static final int MAX_QUESTION_COUNT = 3;
 	private static final String[] VISITOR_ASSIGNMENT_TYPES = {"Quiz", "Homework"};
+	private static final String[] TOPIC_GROUP_NAMES = {
+			"Essential Ideas",
+			"Atoms, molecules and Ions",
+			"Composition of Matter",
+			"Stoichiometry",
+			"Thermochemistry",
+			"Electronic Structure",
+			"Periodic Properties",
+			"Chemical bonding",
+			"Gases",
+			"Liquids and Solids",
+			"Solutions",
+			"Kinetics",
+			"Equilibrium",
+			"Acid-Base Equilibria",
+			"Solubility",
+			"Electrochemistry",
+			"Representative Metals",
+			"Nonmetals and Metalloids",
+			"Organic Chemistry",
+			"Nuclear Chemistry"
+	};
 
 	@Override
 	public String getServletInfo() {
@@ -53,10 +75,11 @@ public class ExampleQuestions extends HttpServlet {
 			JsonObject library = loadSampleQuestionLibrary();
 			if (library != null) {
 				List<Concept> concepts = sampleConcepts(library);
+				Map<Long, Integer> questionCounts = sampleQuestionCounts(library);
 				Map<Long, Concept> conceptMap = conceptMap(concepts);
-				if (conceptId != null && !conceptMap.containsKey(conceptId)) conceptId = null;
+				if (conceptId != null && (!conceptMap.containsKey(conceptId) || !hasSampleQuestions(conceptId, questionCounts))) conceptId = null;
 				List<Question> questions = selectSampleQuestions(library, conceptId, nQuestions);
-				out.println(Subject.header("Example Questions") + renderPage(concepts, conceptMap, questions, conceptId, nQuestions, null) + Subject.footer);
+				out.println(Subject.header("Sample questions") + renderPage(concepts, conceptMap, questionCounts, questions, conceptId, nQuestions, null) + Subject.footer);
 				return;
 			}
 			List<Concept> concepts = loadConcepts();
@@ -65,12 +88,12 @@ public class ExampleQuestions extends HttpServlet {
 			if (conceptId != null && !conceptMap.containsKey(conceptId)) conceptId = null;
 			List<Question> questions = selectQuestions(conceptId, nQuestions);
 			if (questions.isEmpty()) questions = selectSampleQuestions(conceptId, nQuestions);
-			out.println(Subject.header("Example Questions") + renderPage(concepts, conceptMap, questions, conceptId, nQuestions, null) + Subject.footer);
+			out.println(Subject.header("Sample questions") + renderPage(concepts, conceptMap, null, questions, conceptId, nQuestions, null) + Subject.footer);
 		} catch (Exception e) {
 			List<Concept> concepts = sampleConcepts();
 			Map<Long, Concept> conceptMap = conceptMap(concepts);
 			List<Question> questions = selectSampleQuestions(null, nQuestions);
-			out.println(Subject.header("Example Questions") + renderPage(concepts, conceptMap, questions, null, nQuestions,
+			out.println(Subject.header("Sample questions") + renderPage(concepts, conceptMap, null, questions, null, nQuestions,
 					"Example questions could not be loaded from the datastore in this environment.") + Subject.footer);
 		}
 	}
@@ -87,34 +110,34 @@ public class ExampleQuestions extends HttpServlet {
 			JsonObject library = loadSampleQuestionLibrary();
 			if (library != null) {
 				List<Concept> concepts = sampleConcepts(library);
+				Map<Long, Integer> questionCounts = sampleQuestionCounts(library);
 				Map<Long, Concept> conceptMap = conceptMap(concepts);
-				if (conceptId != null && !conceptMap.containsKey(conceptId)) conceptId = null;
-				out.println(Subject.header("Example Questions") + renderResults(request, concepts, conceptMap, conceptId, nQuestions) + Subject.footer);
+				if (conceptId != null && (!conceptMap.containsKey(conceptId) || !hasSampleQuestions(conceptId, questionCounts))) conceptId = null;
+				out.println(Subject.header("Sample questions") + renderResults(request, concepts, conceptMap, questionCounts, conceptId, nQuestions) + Subject.footer);
 				return;
 			}
 			List<Concept> concepts = loadConcepts();
 			if (concepts.isEmpty()) concepts = sampleConcepts();
 			Map<Long, Concept> conceptMap = conceptMap(concepts);
 			if (conceptId != null && !conceptMap.containsKey(conceptId)) conceptId = null;
-			out.println(Subject.header("Example Questions") + renderResults(request, concepts, conceptMap, conceptId, nQuestions) + Subject.footer);
+			out.println(Subject.header("Sample questions") + renderResults(request, concepts, conceptMap, null, conceptId, nQuestions) + Subject.footer);
 		} catch (Exception e) {
 			List<Concept> concepts = sampleConcepts();
 			Map<Long, Concept> conceptMap = conceptMap(concepts);
 			List<Question> questions = selectSampleQuestions(null, nQuestions);
-			out.println(Subject.header("Example Questions") + renderPage(concepts, conceptMap, questions, null, nQuestions,
+			out.println(Subject.header("Sample questions") + renderPage(concepts, conceptMap, null, questions, null, nQuestions,
 					"Submitted answers could not be checked because the datastore is unavailable in this environment.") + Subject.footer);
 		}
 	}
 
-	private String renderPage(List<Concept> concepts,Map<Long,Concept> conceptMap,List<Question> questions,Long selectedConceptId,int nQuestions,String message) {
+	private String renderPage(List<Concept> concepts,Map<Long,Concept> conceptMap,Map<Long,Integer> questionCounts,List<Question> questions,Long selectedConceptId,int nQuestions,String message) {
 		StringBuffer buf = new StringBuffer();
 		buf.append("<main class='container py-4' style='max-width:960px;'>");
 		buf.append("<div class='mb-4'>");
 		buf.append(Subject.banner);
-		buf.append("<h1 class='h2 mt-3'>Example Questions</h1>");
-		buf.append("<p class='lead'>Try three ChemVantage questions. Choose any concept to get a focused sample from that topic.</p>");
+		buf.append("<h1 class='h2 mt-3'>Sample questions</h1>");
 		buf.append("</div>");
-		buf.append(renderChooser(concepts, selectedConceptId, nQuestions));
+		buf.append(renderChooser(concepts, questionCounts, selectedConceptId, nQuestions));
 		if (message != null && !message.isEmpty()) buf.append("<div class='alert alert-warning' role='alert'>" + html(message) + "</div>");
 		if (questions.isEmpty()) {
 			buf.append("<div class='alert alert-info' role='status'>No answerable example questions were found for this selection. Choose another concept or try random questions.</div>");
@@ -126,7 +149,7 @@ public class ExampleQuestions extends HttpServlet {
 		return buf.toString();
 	}
 
-	private String renderChooser(List<Concept> concepts,Long selectedConceptId,int nQuestions) {
+	private String renderChooser(List<Concept> concepts,Map<Long,Integer> questionCounts,Long selectedConceptId,int nQuestions) {
 		StringBuffer buf = new StringBuffer();
 		buf.append("<form class='border rounded-3 p-3 mb-4 bg-light' method='get' action='/example-questions'>");
 		buf.append("<label class='form-label' for='ConceptSearch'>Concept</label>");
@@ -135,20 +158,19 @@ public class ExampleQuestions extends HttpServlet {
 		buf.append("<input id='ConceptId' name='ConceptId' type='hidden' value='").append(selectedConceptId == null?"":selectedConceptId).append("' />");
 		buf.append("<div id='ConceptOptions' class='example-concept-menu position-absolute w-100 shadow-sm' style='display:none;'>");
 		buf.append("<button class='example-concept-chip example-any-concept' type='button' data-concept-id='' data-concept-title='Any concept'>Any concept</button>");
-		buf.append(renderGroupedConceptBrowser(concepts));
+		buf.append(renderGroupedConceptBrowser(concepts, questionCounts));
 		buf.append("</div>");
 		buf.append("</div>");
 		buf.append("</form>");
 		return buf.toString();
 	}
 
-	private String renderGroupedConceptBrowser(List<Concept> concepts) {
+	private String renderGroupedConceptBrowser(List<Concept> concepts,Map<Long,Integer> questionCounts) {
 		StringBuffer buf = new StringBuffer();
 		buf.append("<div id='ConceptGroups' class='example-concept-groups'>");
-		for (int chapter=0;chapter<=25;chapter++) {
-			List<Concept> groupConcepts = conceptsForChapter(concepts, chapter);
+		for (String groupName : TOPIC_GROUP_NAMES) {
+			List<Concept> groupConcepts = conceptsForTopicGroup(concepts, groupName, questionCounts);
 			if (groupConcepts.isEmpty()) continue;
-			String groupName = groupName(chapter);
 			buf.append("<section class='example-concept-group' data-group-title='").append(html(groupName)).append("'>");
 			buf.append("<div class='example-group-title'>").append(html(groupName)).append("</div>");
 			buf.append("<div class='example-group-links'>");
@@ -162,10 +184,49 @@ public class ExampleQuestions extends HttpServlet {
 		return buf.toString();
 	}
 
-	private List<Concept> conceptsForChapter(List<Concept> concepts,int chapter) {
+	private List<Concept> conceptsForTopicGroup(List<Concept> concepts,String groupName,Map<Long,Integer> questionCounts) {
 		List<Concept> groupConcepts = new ArrayList<>();
-		for (Concept c : concepts) if (conceptChapter(c) == chapter) groupConcepts.add(c);
+		for (Concept c : concepts) if (isInTopicGroup(c, groupName) && hasSampleQuestions(c, questionCounts)) groupConcepts.add(c);
 		return groupConcepts;
+	}
+
+	private boolean hasSampleQuestions(Concept c,Map<Long,Integer> questionCounts) {
+		return c != null && c.id != null && hasSampleQuestions(c.id, questionCounts);
+	}
+
+	private boolean hasSampleQuestions(Long conceptId,Map<Long,Integer> questionCounts) {
+		return questionCounts == null || (conceptId != null && questionCounts.getOrDefault(conceptId, 0) > 0);
+	}
+
+	private boolean isInTopicGroup(Concept c,String groupName) {
+		int chapter = conceptChapter(c);
+		return switch (groupName) {
+			case "Essential Ideas" -> chapter == 1;
+			case "Atoms, molecules and Ions" -> chapter == 2;
+			case "Composition of Matter" -> chapter == 3;
+			case "Stoichiometry" -> chapter == 4;
+			case "Thermochemistry" -> chapter == 5;
+			case "Electronic Structure" -> chapter == 6 && !orderByStartsWith(c, "6.5");
+			case "Periodic Properties" -> orderByStartsWith(c, "6.5");
+			case "Chemical bonding" -> chapter == 7 || chapter == 8;
+			case "Gases" -> chapter == 9;
+			case "Liquids and Solids" -> chapter == 10;
+			case "Solutions" -> chapter == 11;
+			case "Kinetics" -> chapter == 12;
+			case "Equilibrium" -> chapter == 13;
+			case "Acid-Base Equilibria" -> chapter == 14;
+			case "Solubility" -> chapter == 15;
+			case "Electrochemistry" -> chapter == 17;
+			case "Representative Metals" -> orderByStartsWith(c, "18.1") || orderByStartsWith(c, "18.2");
+			case "Nonmetals and Metalloids" -> chapter == 18 && !orderByStartsWith(c, "18.1") && !orderByStartsWith(c, "18.2");
+			case "Organic Chemistry" -> chapter == 20;
+			case "Nuclear Chemistry" -> chapter == 21;
+			default -> false;
+		};
+	}
+
+	private boolean orderByStartsWith(Concept c,String prefix) {
+		return c != null && c.orderBy != null && c.orderBy.trim().startsWith(prefix);
 	}
 
 	private int conceptChapter(Concept c) {
@@ -178,38 +239,6 @@ public class ExampleQuestions extends HttpServlet {
 		} catch (Exception e) {
 			return 0;
 		}
-	}
-
-	private String groupName(int chapter) {
-		return switch (chapter) {
-			case 0 -> "Reserved and Internal";
-			case 1 -> "Chapter 1: Foundations and Measurement";
-			case 2 -> "Chapter 2: Atoms, Elements, and Compounds";
-			case 3 -> "Chapter 3: Moles and Concentration";
-			case 4 -> "Chapter 4: Reactions and Stoichiometry";
-			case 5 -> "Chapter 5: Thermochemistry";
-			case 6 -> "Chapter 6: Electronic Structure";
-			case 7 -> "Chapter 7: Bonding and Molecular Structure";
-			case 8 -> "Chapter 8: Advanced Bonding";
-			case 9 -> "Chapter 9: Gases";
-			case 10 -> "Chapter 10: Liquids, Solids, and Intermolecular Forces";
-			case 11 -> "Chapter 11: Solutions";
-			case 12 -> "Chapter 12: Kinetics";
-			case 13 -> "Chapter 13: Equilibrium";
-			case 14 -> "Chapter 14: Acids and Bases";
-			case 15 -> "Chapter 15: Solubility and Complex Ions";
-			case 16 -> "Chapter 16: Thermodynamics";
-			case 17 -> "Chapter 17: Electrochemistry";
-			case 18 -> "Chapter 18: Representative Elements";
-			case 19 -> "Chapter 19: Transition Metals";
-			case 20 -> "Chapter 20: Organic Chemistry";
-			case 21 -> "Chapter 21: Nuclear Chemistry";
-			case 22 -> "Chapter 22: Biochemistry";
-			case 23 -> "Chapter 23: Chemical Separations";
-			case 24 -> "Chapter 24: Environmental Chemistry";
-			case 25 -> "Chapter 25: Molecular Spectroscopy";
-			default -> "Other Concepts";
-		};
 	}
 
 	private String renderQuestionForm(Map<Long,Concept> conceptMap,List<Question> questions,Long selectedConceptId,int nQuestions) {
@@ -238,14 +267,14 @@ public class ExampleQuestions extends HttpServlet {
 		return buf.toString();
 	}
 
-	private String renderResults(HttpServletRequest request,List<Concept> concepts,Map<Long,Concept> conceptMap,Long selectedConceptId,int nQuestions) {
+	private String renderResults(HttpServletRequest request,List<Concept> concepts,Map<Long,Concept> conceptMap,Map<Long,Integer> questionCounts,Long selectedConceptId,int nQuestions) {
 		StringBuffer buf = new StringBuffer();
 		buf.append("<main class='container py-4' style='max-width:960px;'>");
 		buf.append("<div class='mb-4'>");
 		buf.append(Subject.banner);
 		buf.append("<h1 class='h2 mt-3'>Example Question Results</h1>");
 		buf.append("</div>");
-		buf.append(renderChooser(concepts, selectedConceptId, nQuestions));
+		buf.append(renderChooser(concepts, questionCounts, selectedConceptId, nQuestions));
 
 		String[] questionIds = request.getParameterValues("QuestionId");
 		if (questionIds == null || questionIds.length == 0) {
@@ -307,7 +336,7 @@ public class ExampleQuestions extends HttpServlet {
 				+ "function fuzzyConceptMatch(title,query){query=normalizeConceptText(query);title=normalizeConceptText(title);if(!query)return true;if(title.indexOf(query)>=0)return true;var j=0;for(var i=0;i<title.length&&j<query.length;i++)if(title.charAt(i)===query.charAt(j))j++;if(j===query.length)return true;var maxDistance=query.length<5?1:2;if(editDistance(title.substring(0,Math.max(query.length-1,1)),query)<=maxDistance)return true;var words=title.match(/[a-z0-9]+/g)||[];return words.some(function(word){return editDistance(word,query)<=maxDistance||word.indexOf(query)>=0;});}"
 				+ "function groupMatch(group,query){var title=group.dataset.groupTitle||'';return fuzzyConceptMatch(title,query)||normalizeConceptText(title).indexOf(normalizeConceptText(query))>=0;}"
 				+ "function jumpToGroup(query){if(!query||!query.trim())return false;var groups=[].slice.call(document.querySelectorAll('[data-group-title]'));var group=groups.find(function(g){return groupMatch(g,query);});if(!group)return false;group.scrollIntoView({behavior:'smooth',block:'nearest'});group.classList.add('example-group-focus');setTimeout(function(){group.classList.remove('example-group-focus');},1200);return true;}"
-				+ "function wireConceptSearch(){var input=document.getElementById('ConceptSearch'),value=document.getElementById('ConceptId'),menu=document.getElementById('ConceptOptions');if(!input||!value||!menu)return;var items=[].slice.call(menu.querySelectorAll('[data-concept-title]'));var groups=[].slice.call(menu.querySelectorAll('[data-group-title]'));function visibleItem(){return items.find(function(item){return item.offsetParent!==null&&item.style.display!=='none';});}function choose(item,submit){if(!item)return;value.value=item.dataset.conceptId;input.value=item.dataset.conceptTitle==='Any concept'?'':item.dataset.conceptTitle;menu.style.display='none';if(submit)input.form.submit();}function show(){menu.style.display='block';input.setAttribute('aria-expanded','true');filter();}function hide(){setTimeout(function(){menu.style.display='none';input.setAttribute('aria-expanded','false');},150);}function filter(){var q=input.value,shown=0,matchedGroup=false;items.forEach(function(item){var match=fuzzyConceptMatch(item.dataset.conceptTitle,q);item.style.display=match?'inline-block':'none';if(match)shown++;});groups.forEach(function(group){var chips=[].slice.call(group.querySelectorAll('[data-concept-title]'));var groupOnly=q&&groupMatch(group,q);if(groupOnly){matchedGroup=true;chips.forEach(function(chip){chip.style.display='inline-block';});}var hasVisible=chips.some(function(chip){return chip.style.display!=='none';});group.style.display=(hasVisible||groupOnly)?'block':'none';});menu.style.display='block';if(matchedGroup||!shown)jumpToGroup(q);}items.forEach(function(item){item.addEventListener('click',function(){choose(item,true);});});input.addEventListener('focus',show);input.addEventListener('input',function(){value.value='';show();});input.addEventListener('blur',hide);input.addEventListener('keydown',function(e){if(e.key==='Enter'){e.preventDefault();var first=visibleItem();if(first)choose(first,true);else if(!jumpToGroup(input.value))input.form.submit();}});input.form.addEventListener('submit',function(e){if(!value.value&&input.value.trim()){filter();var first=visibleItem();if(first)choose(first,false);else{e.preventDefault();jumpToGroup(input.value);}}});}"
+				+ "function wireConceptSearch(){var input=document.getElementById('ConceptSearch'),value=document.getElementById('ConceptId'),menu=document.getElementById('ConceptOptions');if(!input||!value||!menu)return;var items=[].slice.call(menu.querySelectorAll('[data-concept-title]'));var groups=[].slice.call(menu.querySelectorAll('[data-group-title]'));function visibleItem(){return items.find(function(item){return item.offsetParent!==null&&item.style.display!=='none';});}function showAll(){items.forEach(function(item){item.style.display='inline-block';});groups.forEach(function(group){group.style.display='block';});menu.scrollTop=0;}function choose(item,submit){if(!item)return;value.value=item.dataset.conceptId;input.value=item.dataset.conceptTitle==='Any concept'?'':item.dataset.conceptTitle;menu.style.display='none';if(submit)input.form.submit();}function show(){menu.style.display='block';input.setAttribute('aria-expanded','true');showAll();}function hide(){setTimeout(function(){menu.style.display='none';input.setAttribute('aria-expanded','false');},150);}function filter(){var q=input.value,shown=0,matchedGroup=false;items.forEach(function(item){var match=fuzzyConceptMatch(item.dataset.conceptTitle,q);item.style.display=match?'inline-block':'none';if(match)shown++;});groups.forEach(function(group){var chips=[].slice.call(group.querySelectorAll('[data-concept-title]'));var groupOnly=q&&groupMatch(group,q);if(groupOnly){matchedGroup=true;chips.forEach(function(chip){chip.style.display='inline-block';});}var hasVisible=chips.some(function(chip){return chip.style.display!=='none';});group.style.display=(hasVisible||groupOnly)?'block':'none';});menu.style.display='block';if(matchedGroup||!shown)jumpToGroup(q);}items.forEach(function(item){item.addEventListener('click',function(){choose(item,true);});});input.addEventListener('focus',show);input.addEventListener('click',show);input.addEventListener('input',function(){value.value='';menu.style.display='block';input.setAttribute('aria-expanded','true');filter();});input.addEventListener('blur',hide);input.addEventListener('keydown',function(e){if(e.key==='Enter'){e.preventDefault();var first=visibleItem();if(first)choose(first,true);else if(!jumpToGroup(input.value))input.form.submit();}});input.form.addEventListener('submit',function(e){if(!value.value&&input.value.trim()){filter();var first=visibleItem();if(first)choose(first,false);else{e.preventDefault();jumpToGroup(input.value);}}});}"
 				+ "function showNextExampleHint(qid,total){var state=document.getElementById('hintState'+qid),button=document.getElementById('hintButton'+qid);if(!state||!button)return;var next=parseInt(state.value||'0',10)+1;var hint=document.getElementById('hint'+qid+'_'+next);if(hint)hint.style.display='block';state.value=next;if(next>=total){button.disabled=true;button.innerText='All hints shown';}else button.innerText='Get hint '+(next+1)+' (of '+total+')';}"
 				+ "document.addEventListener('DOMContentLoaded',wireConceptSearch);"
 				+ "</script>"
@@ -388,6 +417,26 @@ public class ExampleQuestions extends HttpServlet {
 		List<Question> questions = sampleQuestions(library, conceptId);
 		if (questions.size() > count) return new ArrayList<>(questions.subList(0, count));
 		return questions;
+	}
+
+	private Map<Long,Integer> sampleQuestionCounts(JsonObject library) {
+		Map<Long,Integer> questionCounts = new HashMap<>();
+		if (library == null || !library.has("concepts")) return questionCounts;
+		JsonArray conceptsJson = library.getAsJsonArray("concepts");
+		for (JsonElement conceptElement : conceptsJson) {
+			JsonObject conceptJson = conceptElement.getAsJsonObject();
+			long cid = conceptJson.get("id").getAsLong();
+			int count = 0;
+			JsonArray questionsJson = conceptJson.getAsJsonArray("questions");
+			for (JsonElement questionElement : questionsJson) {
+				try {
+					Question q = sampleQuestion(questionElement.getAsJsonObject(), cid);
+					if (isRenderableQuestion(q)) count++;
+				} catch (Exception e) {}
+			}
+			questionCounts.put(cid, count);
+		}
+		return questionCounts;
 	}
 
 	private List<Question> sampleQuestions(JsonObject library,Long conceptId) {

--- a/src/main/java/org/chemvantage/ExampleQuestions.java
+++ b/src/main/java/org/chemvantage/ExampleQuestions.java
@@ -1,0 +1,817 @@
+package org.chemvantage;
+
+import static com.googlecode.objectify.ObjectifyService.ofy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Serial;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+@WebServlet(urlPatterns = {"/example-questions", "/example-questions/"})
+public class ExampleQuestions extends HttpServlet {
+	@Serial
+	private static final long serialVersionUID = 137L;
+	private static final int DEFAULT_QUESTION_COUNT = 3;
+	private static final int MAX_QUESTION_COUNT = 3;
+	private static final String[] VISITOR_ASSIGNMENT_TYPES = {"Quiz", "Homework"};
+
+	@Override
+	public String getServletInfo() {
+		return "This servlet serves public ChemVantage example questions.";
+	}
+
+	@Override
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		response.setContentType("text/html;charset=UTF-8");
+		response.setCharacterEncoding("UTF-8");
+		PrintWriter out = response.getWriter();
+
+		int nQuestions = requestedQuestionCount(request);
+		Long conceptId = requestedConceptId(request);
+		try {
+			JsonObject library = loadSampleQuestionLibrary();
+			if (library != null) {
+				List<Concept> concepts = sampleConcepts(library);
+				Map<Long, Concept> conceptMap = conceptMap(concepts);
+				if (conceptId != null && !conceptMap.containsKey(conceptId)) conceptId = null;
+				List<Question> questions = selectSampleQuestions(library, conceptId, nQuestions);
+				out.println(Subject.header("Example Questions") + renderPage(concepts, conceptMap, questions, conceptId, nQuestions, null) + Subject.footer);
+				return;
+			}
+			List<Concept> concepts = loadConcepts();
+			if (concepts.isEmpty()) concepts = sampleConcepts();
+			Map<Long, Concept> conceptMap = conceptMap(concepts);
+			if (conceptId != null && !conceptMap.containsKey(conceptId)) conceptId = null;
+			List<Question> questions = selectQuestions(conceptId, nQuestions);
+			if (questions.isEmpty()) questions = selectSampleQuestions(conceptId, nQuestions);
+			out.println(Subject.header("Example Questions") + renderPage(concepts, conceptMap, questions, conceptId, nQuestions, null) + Subject.footer);
+		} catch (Exception e) {
+			List<Concept> concepts = sampleConcepts();
+			Map<Long, Concept> conceptMap = conceptMap(concepts);
+			List<Question> questions = selectSampleQuestions(null, nQuestions);
+			out.println(Subject.header("Example Questions") + renderPage(concepts, conceptMap, questions, null, nQuestions,
+					"Example questions could not be loaded from the datastore in this environment.") + Subject.footer);
+		}
+	}
+
+	@Override
+	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		response.setContentType("text/html;charset=UTF-8");
+		response.setCharacterEncoding("UTF-8");
+		PrintWriter out = response.getWriter();
+
+		int nQuestions = requestedQuestionCount(request);
+		Long conceptId = requestedConceptId(request);
+		try {
+			JsonObject library = loadSampleQuestionLibrary();
+			if (library != null) {
+				List<Concept> concepts = sampleConcepts(library);
+				Map<Long, Concept> conceptMap = conceptMap(concepts);
+				if (conceptId != null && !conceptMap.containsKey(conceptId)) conceptId = null;
+				out.println(Subject.header("Example Questions") + renderResults(request, concepts, conceptMap, conceptId, nQuestions) + Subject.footer);
+				return;
+			}
+			List<Concept> concepts = loadConcepts();
+			if (concepts.isEmpty()) concepts = sampleConcepts();
+			Map<Long, Concept> conceptMap = conceptMap(concepts);
+			if (conceptId != null && !conceptMap.containsKey(conceptId)) conceptId = null;
+			out.println(Subject.header("Example Questions") + renderResults(request, concepts, conceptMap, conceptId, nQuestions) + Subject.footer);
+		} catch (Exception e) {
+			List<Concept> concepts = sampleConcepts();
+			Map<Long, Concept> conceptMap = conceptMap(concepts);
+			List<Question> questions = selectSampleQuestions(null, nQuestions);
+			out.println(Subject.header("Example Questions") + renderPage(concepts, conceptMap, questions, null, nQuestions,
+					"Submitted answers could not be checked because the datastore is unavailable in this environment.") + Subject.footer);
+		}
+	}
+
+	private String renderPage(List<Concept> concepts,Map<Long,Concept> conceptMap,List<Question> questions,Long selectedConceptId,int nQuestions,String message) {
+		StringBuffer buf = new StringBuffer();
+		buf.append("<main class='container py-4' style='max-width:960px;'>");
+		buf.append("<div class='mb-4'>");
+		buf.append(Subject.banner);
+		buf.append("<h1 class='h2 mt-3'>Example Questions</h1>");
+		buf.append("<p class='lead'>Try three ChemVantage questions. Choose any concept to get a focused sample from that topic.</p>");
+		buf.append("</div>");
+		buf.append(renderChooser(concepts, selectedConceptId, nQuestions));
+		if (message != null && !message.isEmpty()) buf.append("<div class='alert alert-warning' role='alert'>" + html(message) + "</div>");
+		if (questions.isEmpty()) {
+			buf.append("<div class='alert alert-info' role='status'>No answerable example questions were found for this selection. Choose another concept or try random questions.</div>");
+		} else {
+			buf.append(renderQuestionForm(conceptMap, questions, selectedConceptId, nQuestions));
+		}
+		buf.append("</main>");
+		buf.append(renderScripts());
+		return buf.toString();
+	}
+
+	private String renderChooser(List<Concept> concepts,Long selectedConceptId,int nQuestions) {
+		StringBuffer buf = new StringBuffer();
+		buf.append("<form class='border rounded-3 p-3 mb-4 bg-light' method='get' action='/example-questions'>");
+		buf.append("<label class='form-label' for='ConceptSearch'>Concept</label>");
+		buf.append("<div class='position-relative'>");
+		buf.append("<input class='form-control' id='ConceptSearch' type='search' autocomplete='off' role='combobox' aria-expanded='false' aria-controls='ConceptOptions' placeholder='Any concept' value='").append(html(conceptTitle(conceptMap(concepts), selectedConceptId))).append("' />");
+		buf.append("<input id='ConceptId' name='ConceptId' type='hidden' value='").append(selectedConceptId == null?"":selectedConceptId).append("' />");
+		buf.append("<div id='ConceptOptions' class='example-concept-menu position-absolute w-100 shadow-sm' style='display:none;'>");
+		buf.append("<button class='example-concept-chip example-any-concept' type='button' data-concept-id='' data-concept-title='Any concept'>Any concept</button>");
+		buf.append(renderGroupedConceptBrowser(concepts));
+		buf.append("</div>");
+		buf.append("</div>");
+		buf.append("</form>");
+		return buf.toString();
+	}
+
+	private String renderGroupedConceptBrowser(List<Concept> concepts) {
+		StringBuffer buf = new StringBuffer();
+		buf.append("<div id='ConceptGroups' class='example-concept-groups'>");
+		for (int chapter=0;chapter<=25;chapter++) {
+			List<Concept> groupConcepts = conceptsForChapter(concepts, chapter);
+			if (groupConcepts.isEmpty()) continue;
+			String groupName = groupName(chapter);
+			buf.append("<section class='example-concept-group' data-group-title='").append(html(groupName)).append("'>");
+			buf.append("<div class='example-group-title'>").append(html(groupName)).append("</div>");
+			buf.append("<div class='example-group-links'>");
+			for (Concept c : groupConcepts) {
+				buf.append("<button class='example-concept-chip' type='button' data-concept-id='").append(c.id).append("' data-concept-title='").append(html(c.title)).append("'>").append(html(c.title)).append("</button>");
+			}
+			buf.append("</div>");
+			buf.append("</section>");
+		}
+		buf.append("</div>");
+		return buf.toString();
+	}
+
+	private List<Concept> conceptsForChapter(List<Concept> concepts,int chapter) {
+		List<Concept> groupConcepts = new ArrayList<>();
+		for (Concept c : concepts) if (conceptChapter(c) == chapter) groupConcepts.add(c);
+		return groupConcepts;
+	}
+
+	private int conceptChapter(Concept c) {
+		if (c == null || c.orderBy == null) return 0;
+		try {
+			String orderBy = c.orderBy.trim();
+			int decimal = orderBy.indexOf('.');
+			String chapter = decimal < 0?orderBy:orderBy.substring(0, decimal);
+			return Integer.parseInt(chapter);
+		} catch (Exception e) {
+			return 0;
+		}
+	}
+
+	private String groupName(int chapter) {
+		return switch (chapter) {
+			case 0 -> "Reserved and Internal";
+			case 1 -> "Chapter 1: Foundations and Measurement";
+			case 2 -> "Chapter 2: Atoms, Elements, and Compounds";
+			case 3 -> "Chapter 3: Moles and Concentration";
+			case 4 -> "Chapter 4: Reactions and Stoichiometry";
+			case 5 -> "Chapter 5: Thermochemistry";
+			case 6 -> "Chapter 6: Electronic Structure";
+			case 7 -> "Chapter 7: Bonding and Molecular Structure";
+			case 8 -> "Chapter 8: Advanced Bonding";
+			case 9 -> "Chapter 9: Gases";
+			case 10 -> "Chapter 10: Liquids, Solids, and Intermolecular Forces";
+			case 11 -> "Chapter 11: Solutions";
+			case 12 -> "Chapter 12: Kinetics";
+			case 13 -> "Chapter 13: Equilibrium";
+			case 14 -> "Chapter 14: Acids and Bases";
+			case 15 -> "Chapter 15: Solubility and Complex Ions";
+			case 16 -> "Chapter 16: Thermodynamics";
+			case 17 -> "Chapter 17: Electrochemistry";
+			case 18 -> "Chapter 18: Representative Elements";
+			case 19 -> "Chapter 19: Transition Metals";
+			case 20 -> "Chapter 20: Organic Chemistry";
+			case 21 -> "Chapter 21: Nuclear Chemistry";
+			case 22 -> "Chapter 22: Biochemistry";
+			case 23 -> "Chapter 23: Chemical Separations";
+			case 24 -> "Chapter 24: Environmental Chemistry";
+			case 25 -> "Chapter 25: Molecular Spectroscopy";
+			default -> "Other Concepts";
+		};
+	}
+
+	private String renderQuestionForm(Map<Long,Concept> conceptMap,List<Question> questions,Long selectedConceptId,int nQuestions) {
+		StringBuffer buf = new StringBuffer();
+		Random rand = new Random();
+		buf.append("<form method='post' action='/example-questions' onsubmit='return false;'>");
+		buf.append("<input type='hidden' name='n' value='").append(nQuestions).append("' />");
+		if (selectedConceptId != null) buf.append("<input type='hidden' name='ConceptId' value='").append(selectedConceptId).append("' />");
+		int questionNumber = 1;
+		for (Question q : questions) {
+			long parameter = Math.abs(rand.nextLong());
+			q.setParameters(parameter);
+			buf.append("<section class='border rounded-3 p-4 mb-3 bg-white'>");
+			buf.append("<div class='d-flex flex-wrap justify-content-between align-items-start gap-2 mb-3'>");
+			buf.append("<h2 class='h5 mb-0'>Question ").append(questionNumber++).append("</h2>");
+			String conceptTitle = conceptTitle(conceptMap, q.conceptId);
+			if (!conceptTitle.isEmpty()) buf.append("<span class='badge text-bg-light border'>").append(html(conceptTitle)).append("</span>");
+			buf.append("</div>");
+			buf.append("<input type='hidden' name='QuestionId' value='").append(q.id).append("' />");
+			buf.append("<input type='hidden' name='p").append(q.id).append("' value='").append(parameter).append("' />");
+			buf.append(q.print());
+			buf.append(renderHintControls(q));
+			buf.append("</section>");
+		}
+		buf.append("</form>");
+		return buf.toString();
+	}
+
+	private String renderResults(HttpServletRequest request,List<Concept> concepts,Map<Long,Concept> conceptMap,Long selectedConceptId,int nQuestions) {
+		StringBuffer buf = new StringBuffer();
+		buf.append("<main class='container py-4' style='max-width:960px;'>");
+		buf.append("<div class='mb-4'>");
+		buf.append(Subject.banner);
+		buf.append("<h1 class='h2 mt-3'>Example Question Results</h1>");
+		buf.append("</div>");
+		buf.append(renderChooser(concepts, selectedConceptId, nQuestions));
+
+		String[] questionIds = request.getParameterValues("QuestionId");
+		if (questionIds == null || questionIds.length == 0) {
+			buf.append("<div class='alert alert-warning' role='alert'>No questions were submitted.</div>");
+			buf.append("</main>").append(renderScripts());
+			return buf.toString();
+		}
+
+		int correct = 0;
+		List<String> questionResults = new ArrayList<>();
+		for (String questionId : questionIds) {
+			try {
+				long qid = Long.parseLong(questionId);
+				Question q = qid < 0L?sampleQuestion(qid):ofy().load().type(Question.class).id(qid).safe();
+				if (!isVisitorQuestion(q)) continue;
+				long parameter = parseLong(request.getParameter("p" + qid), System.currentTimeMillis());
+				q.setParameters(parameter);
+				String answer = orderResponses(request.getParameterValues(String.valueOf(qid)));
+				String showWork = request.getParameter("ShowWork" + qid);
+				boolean isCorrect = q.isCorrect(answer);
+				if (isCorrect) correct++;
+				questionResults.add(renderQuestionResult(q, conceptMap, answer, showWork, isCorrect, questionResults.size() + 1));
+			} catch (Exception e) {
+				questionResults.add("<section class='border rounded-3 p-4 mb-3 bg-white'><h2 class='h5'>Question " + (questionResults.size() + 1) + "</h2><div class='alert alert-warning'>This question could not be scored.</div></section>");
+			}
+		}
+
+		buf.append("<div class='alert alert-primary' role='status'>You answered <b>").append(correct).append("</b> of <b>").append(questionResults.size()).append("</b> questions correctly.</div>");
+		for (String questionResult : questionResults) buf.append(questionResult);
+		buf.append("<div class='d-flex flex-wrap gap-2 mb-5'>");
+		buf.append("<a class='btn btn-primary btn-lg' href='").append(newQuestionUrl(selectedConceptId, DEFAULT_QUESTION_COUNT)).append("'>Get 5 New Questions</a>");
+		buf.append("<a class='btn btn-outline-secondary btn-lg' href='/example-questions'>Try Random Questions</a>");
+		buf.append("</div>");
+		buf.append("</main>");
+		buf.append(renderScripts());
+		return buf.toString();
+	}
+
+	private String renderQuestionResult(Question q,Map<Long,Concept> conceptMap,String answer,String showWork,boolean isCorrect,int questionNumber) {
+		StringBuffer buf = new StringBuffer();
+		buf.append("<section class='border rounded-3 p-4 mb-3 bg-white'>");
+		buf.append("<div class='d-flex flex-wrap justify-content-between align-items-start gap-2 mb-3'>");
+		buf.append("<h2 class='h5 mb-0'>Question ").append(questionNumber).append("</h2>");
+		buf.append("<span class='badge ").append(isCorrect?"text-bg-success":"text-bg-danger").append("'>").append(isCorrect?"Correct":"Incorrect").append("</span>");
+		String conceptTitle = conceptTitle(conceptMap, q.conceptId);
+		if (!conceptTitle.isEmpty()) buf.append("<span class='badge text-bg-light border'>").append(html(conceptTitle)).append("</span>");
+		buf.append("</div>");
+		buf.append(q.printAllToStudents(studentAnswerHtml(answer), true, false, html(showWork)));
+		buf.append("</section>");
+		return buf.toString();
+	}
+
+	private String renderScripts() {
+		return "<script>"
+				+ "function showWorkBox(qid){var el=document.getElementById('showWork'+qid);if(el)el.style.display='block';}"
+				+ "function waitForExampleScore(){var b=document.getElementById('SubmitButton');if(b){b.disabled=true;b.innerText='Checking answers...';}return true;}"
+				+ "function normalizeConceptText(s){return (s||'').toLowerCase().replace(/[^a-z0-9]+/g,'');}"
+				+ "function editDistance(a,b){var m=a.length,n=b.length,dp=[];for(var i=0;i<=m;i++){dp[i]=[i];}for(var j=1;j<=n;j++)dp[0][j]=j;for(i=1;i<=m;i++){for(j=1;j<=n;j++){var cost=a.charAt(i-1)===b.charAt(j-1)?0:1;dp[i][j]=Math.min(dp[i-1][j]+1,dp[i][j-1]+1,dp[i-1][j-1]+cost);}}return dp[m][n];}"
+				+ "function fuzzyConceptMatch(title,query){query=normalizeConceptText(query);title=normalizeConceptText(title);if(!query)return true;if(title.indexOf(query)>=0)return true;var j=0;for(var i=0;i<title.length&&j<query.length;i++)if(title.charAt(i)===query.charAt(j))j++;if(j===query.length)return true;var maxDistance=query.length<5?1:2;if(editDistance(title.substring(0,Math.max(query.length-1,1)),query)<=maxDistance)return true;var words=title.match(/[a-z0-9]+/g)||[];return words.some(function(word){return editDistance(word,query)<=maxDistance||word.indexOf(query)>=0;});}"
+				+ "function groupMatch(group,query){var title=group.dataset.groupTitle||'';return fuzzyConceptMatch(title,query)||normalizeConceptText(title).indexOf(normalizeConceptText(query))>=0;}"
+				+ "function jumpToGroup(query){if(!query||!query.trim())return false;var groups=[].slice.call(document.querySelectorAll('[data-group-title]'));var group=groups.find(function(g){return groupMatch(g,query);});if(!group)return false;group.scrollIntoView({behavior:'smooth',block:'nearest'});group.classList.add('example-group-focus');setTimeout(function(){group.classList.remove('example-group-focus');},1200);return true;}"
+				+ "function wireConceptSearch(){var input=document.getElementById('ConceptSearch'),value=document.getElementById('ConceptId'),menu=document.getElementById('ConceptOptions');if(!input||!value||!menu)return;var items=[].slice.call(menu.querySelectorAll('[data-concept-title]'));var groups=[].slice.call(menu.querySelectorAll('[data-group-title]'));function visibleItem(){return items.find(function(item){return item.offsetParent!==null&&item.style.display!=='none';});}function choose(item,submit){if(!item)return;value.value=item.dataset.conceptId;input.value=item.dataset.conceptTitle==='Any concept'?'':item.dataset.conceptTitle;menu.style.display='none';if(submit)input.form.submit();}function show(){menu.style.display='block';input.setAttribute('aria-expanded','true');filter();}function hide(){setTimeout(function(){menu.style.display='none';input.setAttribute('aria-expanded','false');},150);}function filter(){var q=input.value,shown=0,matchedGroup=false;items.forEach(function(item){var match=fuzzyConceptMatch(item.dataset.conceptTitle,q);item.style.display=match?'inline-block':'none';if(match)shown++;});groups.forEach(function(group){var chips=[].slice.call(group.querySelectorAll('[data-concept-title]'));var groupOnly=q&&groupMatch(group,q);if(groupOnly){matchedGroup=true;chips.forEach(function(chip){chip.style.display='inline-block';});}var hasVisible=chips.some(function(chip){return chip.style.display!=='none';});group.style.display=(hasVisible||groupOnly)?'block':'none';});menu.style.display='block';if(matchedGroup||!shown)jumpToGroup(q);}items.forEach(function(item){item.addEventListener('click',function(){choose(item,true);});});input.addEventListener('focus',show);input.addEventListener('input',function(){value.value='';show();});input.addEventListener('blur',hide);input.addEventListener('keydown',function(e){if(e.key==='Enter'){e.preventDefault();var first=visibleItem();if(first)choose(first,true);else if(!jumpToGroup(input.value))input.form.submit();}});input.form.addEventListener('submit',function(e){if(!value.value&&input.value.trim()){filter();var first=visibleItem();if(first)choose(first,false);else{e.preventDefault();jumpToGroup(input.value);}}});}"
+				+ "function showNextExampleHint(qid,total){var state=document.getElementById('hintState'+qid),button=document.getElementById('hintButton'+qid);if(!state||!button)return;var next=parseInt(state.value||'0',10)+1;var hint=document.getElementById('hint'+qid+'_'+next);if(hint)hint.style.display='block';state.value=next;if(next>=total){button.disabled=true;button.innerText='All hints shown';}else button.innerText='Get hint '+(next+1)+' (of '+total+')';}"
+				+ "document.addEventListener('DOMContentLoaded',wireConceptSearch);"
+				+ "</script>"
+				+ "<style>"
+				+ ".example-hint{border:1px solid #a8d8ea;border-left:5px solid #0b84a5;background:linear-gradient(90deg,#f0fbff 0%,#ffffff 75%);border-radius:.5rem;padding:.85rem 1rem;box-shadow:0 .35rem 1rem rgba(11,132,165,.08);}"
+				+ ".example-hint-label{font-size:.72rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#0b6982;margin-bottom:.2rem;}"
+				+ ".example-hint-button{border-color:#0b84a5;color:#0b6982;font-weight:600;}"
+				+ ".example-hint-button:hover,.example-hint-button:focus{background:#0b84a5;border-color:#0b84a5;color:#fff;}"
+				+ ".example-hint-button:disabled{background:#e8f6fa;border-color:#a8d8ea;color:#457987;opacity:1;}"
+				+ ".example-concept-menu{z-index:1000;max-height:28rem;overflow:auto;background:#fff;border:1px solid #cfdde2;border-radius:.5rem;padding:.75rem;}"
+				+ ".example-concept-groups{border-top:1px solid #d8e2e7;padding-top:.75rem;margin-top:.65rem;}"
+				+ ".example-concept-group{border:1px solid #d8e2e7;border-radius:.5rem;background:#fff;margin-bottom:.75rem;padding:.75rem;transition:box-shadow .2s,border-color .2s;}"
+				+ ".example-concept-group.example-group-focus{border-color:#0b84a5;box-shadow:0 0 0 .2rem rgba(11,132,165,.16);}"
+				+ ".example-group-title{font-size:.8rem;font-weight:700;color:#37515c;text-transform:uppercase;letter-spacing:.04em;margin-bottom:.5rem;}"
+				+ ".example-group-links{display:flex;flex-wrap:wrap;gap:.4rem;}"
+				+ ".example-concept-chip{border:1px solid #c9d9df;background:#f8fbfc;color:#24424f;border-radius:999px;padding:.25rem .65rem;font-size:.85rem;line-height:1.35;}"
+				+ ".example-any-concept{margin-bottom:.15rem;}"
+				+ ".example-concept-chip:hover,.example-concept-chip:focus{border-color:#0b84a5;background:#eef9fc;color:#073f4e;}"
+				+ "</style>";
+	}
+
+	private String renderHintControls(Question q) {
+		List<String> hints = hints(q);
+		if (hints.isEmpty()) return "";
+		StringBuffer buf = new StringBuffer();
+		buf.append("<div class='mt-3'>");
+		buf.append("<input id='hintState").append(q.id).append("' type='hidden' value='0' />");
+		for (int i=0;i<hints.size();i++) {
+			buf.append("<div id='hint").append(q.id).append("_").append(i+1).append("' class='example-hint mb-2' style='display:none;'>");
+			buf.append("<div class='example-hint-label'>Hint ").append(i+1).append("</div>");
+			buf.append("<div>").append(hints.get(i)).append("</div>");
+			buf.append("</div>");
+		}
+		buf.append("<button id='hintButton").append(q.id).append("' class='btn btn-outline-primary btn-sm example-hint-button' type='button' onclick='showNextExampleHint(\"")
+				.append(q.id).append("\",").append(hints.size()).append(");'>Get hint 1 (of ").append(hints.size()).append(")</button>");
+		buf.append("</div>");
+		return buf.toString();
+	}
+
+	private List<String> hints(Question q) {
+		List<String> hints = new ArrayList<>();
+		if (q == null || q.hint == null || q.hint.isBlank()) return hints;
+		String[] pieces = q.hint.split("\\s*(?:\\|\\||\\r?\\n|<br\\s*/?>)\\s*");
+		for (String piece : pieces) {
+			if (piece == null || piece.isBlank()) continue;
+			hints.add(q.parseString(piece.trim()));
+		}
+		return hints;
+	}
+
+	private JsonObject loadSampleQuestionLibrary() {
+		InputStream input = getServletContext().getResourceAsStream("/sampleQuestionLibrary.json");
+		if (input == null) input = getClass().getClassLoader().getResourceAsStream("META-INF/resources/sampleQuestionLibrary.json");
+		if (input == null) return null;
+		try (Reader reader = new InputStreamReader(input, StandardCharsets.UTF_8)) {
+			return JsonParser.parseReader(reader).getAsJsonObject();
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	private List<Concept> sampleConcepts(JsonObject library) {
+		List<Concept> concepts = new ArrayList<>();
+		if (library == null || !library.has("concepts")) return concepts;
+		JsonArray conceptsJson = library.getAsJsonArray("concepts");
+		for (JsonElement conceptElement : conceptsJson) {
+			JsonObject conceptJson = conceptElement.getAsJsonObject();
+			Concept concept = sampleConcept(
+					conceptJson.get("id").getAsLong(),
+					conceptJson.get("title").getAsString(),
+					conceptJson.has("orderBy")?conceptJson.get("orderBy").getAsString():"");
+			concepts.add(concept);
+		}
+		return concepts;
+	}
+
+	private List<Question> selectSampleQuestions(JsonObject library,Long conceptId,int count) {
+		List<Question> questions = sampleQuestions(library, conceptId);
+		if (questions.size() > count) return new ArrayList<>(questions.subList(0, count));
+		return questions;
+	}
+
+	private List<Question> sampleQuestions(JsonObject library,Long conceptId) {
+		List<Question> questions = new ArrayList<>();
+		if (library == null || !library.has("concepts")) return questions;
+		JsonArray conceptsJson = library.getAsJsonArray("concepts");
+		for (JsonElement conceptElement : conceptsJson) {
+			JsonObject conceptJson = conceptElement.getAsJsonObject();
+			long cid = conceptJson.get("id").getAsLong();
+			if (conceptId != null && !conceptId.equals(cid)) continue;
+			JsonArray questionsJson = conceptJson.getAsJsonArray("questions");
+			for (JsonElement questionElement : questionsJson) {
+				try {
+					Question q = sampleQuestion(questionElement.getAsJsonObject(), cid);
+					if (isRenderableQuestion(q)) questions.add(q);
+					if (conceptId == null && questions.size() >= MAX_QUESTION_COUNT) return questions;
+				} catch (Exception e) {}
+			}
+			if (conceptId != null) break;
+		}
+		return questions;
+	}
+
+	private boolean isRenderableQuestion(Question q) {
+		if (q == null || q.id == null || q.type == null) return false;
+		int questionType = q.getQuestionType();
+		if (questionType < Question.MULTIPLE_CHOICE || questionType > Question.ESSAY) return false;
+		if (questionType != Question.ESSAY && q.hasNoCorrectAnswer()) return false;
+		if (questionType == Question.MULTIPLE_CHOICE || questionType == Question.SELECT_MULTIPLE) {
+			if (q.choices == null || q.nChoices == null || q.choices.size() < q.nChoices || q.nChoices < 2) return false;
+			for (char answer : q.correctAnswer.toCharArray()) {
+				int index = answer - 'a';
+				if (index < 0 || index >= q.nChoices) return false;
+			}
+		}
+		return true;
+	}
+
+	private Question sampleQuestion(JsonObject questionJson,long conceptId) {
+		String type = questionJson.get("type").getAsString();
+		Question q = sampleQuestionBase(
+				questionJson.get("id").getAsLong(),
+				conceptId,
+				Question.getQuestionType(type),
+				questionJson.get("text").getAsString(),
+				questionJson.get("correctAnswer").getAsString());
+		if (questionJson.has("choices") && questionJson.get("choices").isJsonArray()) {
+			q.choices = new ArrayList<>();
+			JsonArray choicesJson = questionJson.getAsJsonArray("choices");
+			for (JsonElement choice : choicesJson) q.choices.add(choice.getAsString());
+			q.nChoices = q.choices.size();
+		}
+		if (questionJson.has("requiredPrecision")) q.requiredPrecision = questionJson.get("requiredPrecision").getAsDouble();
+		if (questionJson.has("significantFigures")) q.significantFigures = questionJson.get("significantFigures").getAsInt();
+		if (questionJson.has("tag")) q.tag = questionJson.get("tag").getAsString();
+		if (questionJson.has("parameterString")) q.parameterString = questionJson.get("parameterString").getAsString();
+		if (questionJson.has("solution")) q.solution = questionJson.get("solution").getAsString();
+		if (questionJson.has("scrambleChoices")) q.scrambleChoices = questionJson.get("scrambleChoices").getAsBoolean();
+		if (questionJson.has("strictSpelling")) q.strictSpelling = questionJson.get("strictSpelling").getAsBoolean();
+		if (questionJson.has("hints")) {
+			List<String> hints = new ArrayList<>();
+			JsonArray hintsJson = questionJson.getAsJsonArray("hints");
+			for (JsonElement hint : hintsJson) hints.add(hint.getAsString());
+			q.hint = String.join("||", hints);
+		}
+		return q;
+	}
+
+	private List<Question> selectQuestions(Long conceptId,int count) {
+		Random rand = new Random();
+		List<Question> candidates = new ArrayList<>();
+		if (conceptId != null) {
+			candidates.addAll(loadConceptQuestions(conceptId));
+		} else {
+			List<Concept> concepts = loadConcepts();
+			Collections.shuffle(concepts, rand);
+			for (Concept concept : concepts) {
+				if (concept.id == null) continue;
+				List<Question> conceptQuestions = loadConceptQuestions(concept.id);
+				Collections.shuffle(conceptQuestions, rand);
+				int nConceptQuestions = Math.min(2, conceptQuestions.size());
+				candidates.addAll(conceptQuestions.subList(0, nConceptQuestions));
+				if (candidates.size() >= count * 6) break;
+			}
+		}
+		Collections.shuffle(candidates, rand);
+		if (candidates.size() > count) return new ArrayList<>(candidates.subList(0, count));
+		return candidates;
+	}
+
+	private List<Question> loadConceptQuestions(Long conceptId) {
+		List<Question> eligible = new ArrayList<>();
+		List<Question> active = new ArrayList<>();
+		for (String assignmentType : VISITOR_ASSIGNMENT_TYPES) {
+			List<Question> questions = ofy().load().type(Question.class).filter("conceptId", conceptId).filter("assignmentType", assignmentType).list();
+			for (Question q : questions) {
+				if (!isVisitorQuestion(q)) continue;
+				eligible.add(q);
+				if (q.isActive) active.add(q);
+			}
+		}
+		return active.isEmpty()?eligible:active;
+	}
+
+	private List<Question> selectSampleQuestions(Long conceptId,int count) {
+		List<Question> samples = sampleQuestions();
+		if (conceptId != null) samples.removeIf(q -> !conceptId.equals(q.conceptId));
+		Collections.shuffle(samples, new Random());
+		if (samples.size() > count) return new ArrayList<>(samples.subList(0, count));
+		return samples;
+	}
+
+	private Question sampleQuestion(long questionId) {
+		JsonObject library = loadSampleQuestionLibrary();
+		for (Question q : sampleQuestions(library, null)) if (q.id != null && q.id == questionId) return q;
+		for (Question q : sampleQuestions()) if (q.id != null && q.id == questionId) return q;
+		return null;
+	}
+
+	private boolean useSampleQuestions(HttpServletRequest request) {
+		String serverName = request.getServerName();
+		return "localhost".equals(serverName) || "127.0.0.1".equals(serverName);
+	}
+
+	private List<Concept> sampleConcepts() {
+		List<Concept> concepts = new ArrayList<>();
+		concepts.add(sampleConcept(-101L, "Atoms and Molecules", " 01"));
+		concepts.add(sampleConcept(-102L, "Measurement and Units", " 02"));
+		concepts.add(sampleConcept(-103L, "Atomic Structure", " 03"));
+		concepts.add(sampleConcept(-104L, "Periodic Trends", " 04"));
+		concepts.add(sampleConcept(-105L, "Ions and Ionic Compounds", " 05"));
+		concepts.add(sampleConcept(-106L, "Molecular Compounds", " 06"));
+		concepts.add(sampleConcept(-107L, "Chemical Reactions", " 07"));
+		concepts.add(sampleConcept(-108L, "Stoichiometry", " 08"));
+		concepts.add(sampleConcept(-109L, "Aqueous Solutions", " 09"));
+		concepts.add(sampleConcept(-110L, "Thermochemistry", " 10"));
+		concepts.add(sampleConcept(-111L, "Electronic Structure", " 11"));
+		concepts.add(sampleConcept(-112L, "Chemical Bonding", " 12"));
+		concepts.add(sampleConcept(-113L, "Molecular Geometry", " 13"));
+		concepts.add(sampleConcept(-114L, "Gases", " 14"));
+		concepts.add(sampleConcept(-115L, "Liquids and Solids", " 15"));
+		concepts.add(sampleConcept(-116L, "Solutions and Colligative Properties", " 16"));
+		concepts.add(sampleConcept(-117L, "Chemical Kinetics", " 17"));
+		concepts.add(sampleConcept(-118L, "Chemical Equilibrium", " 18"));
+		concepts.add(sampleConcept(-119L, "Acids and Bases", " 19"));
+		concepts.add(sampleConcept(-120L, "Solubility Equilibria", " 20"));
+		concepts.add(sampleConcept(-121L, "Thermodynamics", " 21"));
+		concepts.add(sampleConcept(-122L, "Electrochemistry", " 22"));
+		concepts.add(sampleConcept(-123L, "Nuclear Chemistry", " 23"));
+		concepts.add(sampleConcept(-124L, "Organic Chemistry", " 24"));
+		return concepts;
+	}
+
+	private Concept sampleConcept(long id,String title,String orderBy) {
+		Concept c = new Concept(title, orderBy);
+		c.id = id;
+		return c;
+	}
+
+	private List<Question> sampleQuestions() {
+		List<Question> questions = new ArrayList<>();
+		questions.add(withHints(sampleMultipleChoice(-1001L, -101L,
+				"Which particle has a negative electric charge?",
+				List.of("proton", "neutron", "electron", "nucleus"), "c"),
+				"Look for the subatomic particle that moves around the nucleus.",
+				"Protons are positive, neutrons are neutral, and electrons are negative."));
+		questions.add(withHints(sampleNumeric(-1002L, -102L,
+				"How many milliliters are in 2.50 L?", "2500", "mL"),
+				"Use 1 L = 1000 mL.",
+				"Multiply 2.50 by 1000."));
+		questions.add(withHints(sampleMultipleChoice(-1003L, -103L,
+				"Which subatomic particle determines the identity of an element?",
+				List.of("electron", "neutron", "proton", "photon"), "c"),
+				"An element's atomic number is the count you need.",
+				"Atomic number equals the number of protons."));
+		questions.add(withHints(sampleMultipleChoice(-1004L, -104L,
+				"Which element has the larger atomic radius?",
+				List.of("F", "Cl", "Br", "I"), "d"),
+				"Atomic radius increases down a group.",
+				"Iodine is lowest in this halogen list."));
+		questions.add(withHints(sampleMultipleChoice(-1005L, -105L,
+				"What is the formula of magnesium chloride?",
+				List.of("MgCl", "MgCl2", "Mg2Cl", "Mg2Cl2"), "b"),
+				"Magnesium forms Mg2+ and chloride forms Cl-.",
+				"Two chloride ions are needed to balance one magnesium ion."));
+		questions.add(withHints(sampleMultipleChoice(-1006L, -106L,
+				"Which molecule is carbon dioxide?",
+				List.of("CO", "CO2", "C2O", "C2O2"), "b"),
+				"The prefix di- means two.",
+				"Carbon dioxide has one carbon atom and two oxygen atoms."));
+		questions.add(withHints(sampleMultipleChoice(-1007L, -107L,
+				"In the balanced equation 2 H2 + O2 -> 2 H2O, what coefficient belongs in front of H2O?",
+				List.of("1", "2", "3", "4"), "b"),
+				"Count oxygen atoms on each side.",
+				"One O2 molecule provides two oxygen atoms, so two water molecules are formed."));
+		questions.add(withHints(sampleSelectMultiple(-1008L, -107L,
+				"Which observations commonly indicate that a chemical reaction has occurred?",
+				List.of("gas bubbles form", "a precipitate forms", "mass disappears", "temperature changes"), "abd"),
+				"Look for signs that new substances formed.",
+				"Mass is conserved, so it should not disappear."));
+		questions.add(withHints(sampleNumeric(-1009L, -108L,
+				"How many moles are in 18.0 g of H2O?", "1.00", "mol"),
+				"The molar mass of water is 18.0 g/mol.",
+				"moles = mass divided by molar mass."));
+		questions.add(withHints(sampleTrueFalse(-1010L, -109L,
+				"A strong electrolyte dissociates extensively into ions in water.", true),
+				"Electrolytes conduct because ions move in solution.",
+				"Strong means nearly complete dissociation."));
+		questions.add(withHints(sampleMultipleChoice(-1011L, -110L,
+				"An exothermic process has which sign for enthalpy change?",
+				List.of("positive", "negative", "zero", "undefined"), "b"),
+				"Exothermic processes release heat.",
+				"Released heat leaves the system, so delta H is negative."));
+		questions.add(withHints(sampleMultipleChoice(-1012L, -111L,
+				"How many electrons can fit in a single orbital?",
+				List.of("1", "2", "6", "8"), "b"),
+				"Use the Pauli exclusion principle.",
+				"Two electrons can share an orbital if their spins are opposite."));
+		questions.add(withHints(sampleMultipleChoice(-1013L, -112L,
+				"What type of bond forms when electrons are shared?",
+				List.of("ionic", "covalent", "metallic", "hydrogen"), "b"),
+				"Shared electrons are typical of molecular compounds.",
+				"Covalent bonds involve sharing electron pairs."));
+		questions.add(withHints(sampleMultipleChoice(-1014L, -113L,
+				"What is the electron-domain geometry around carbon in CH4?",
+				List.of("linear", "trigonal planar", "tetrahedral", "octahedral"), "c"),
+				"Count the electron domains around carbon.",
+				"Four bonding domains give a tetrahedral arrangement."));
+		questions.add(withHints(sampleNumeric(-1015L, -114L,
+				"What volume does 1.00 mol of an ideal gas occupy at STP?", "22.4", "L"),
+				"Recall the molar volume of an ideal gas at STP.",
+				"At STP, 1 mol occupies 22.4 L."));
+		questions.add(withHints(sampleMultipleChoice(-1016L, -115L,
+				"Which intermolecular force is present in all substances?",
+				List.of("London dispersion", "hydrogen bonding", "ion-dipole", "covalent bonding"), "a"),
+				"Even nonpolar atoms and molecules attract one another weakly.",
+				"London dispersion forces arise from temporary electron fluctuations."));
+		questions.add(withHints(sampleMultipleChoice(-1017L, -116L,
+				"Adding a nonvolatile solute to a solvent usually does what to the boiling point?",
+				List.of("lowers it", "raises it", "does not change it", "sets it to 0 C"), "b"),
+				"Think colligative properties.",
+				"Boiling point elevation raises the boiling point."));
+		questions.add(withHints(sampleMultipleChoice(-1018L, -117L,
+				"What happens to reaction rate when temperature is usually increased?",
+				List.of("it decreases", "it increases", "it becomes zero", "it is unrelated"), "b"),
+				"Higher temperature means particles have more kinetic energy.",
+				"More particles can overcome activation energy."));
+		questions.add(withHints(sampleTrueFalse(-1019L, -118L,
+				"At equilibrium, forward and reverse reaction rates are equal.", true),
+				"Equilibrium is dynamic, not stopped.",
+				"Equal rates keep concentrations constant."));
+		questions.add(withHints(sampleFillInWord(-1020L, -119L,
+				"A substance that donates H+ ions in water is called a(n) ________.", "acid"),
+				"Use the Arrhenius acid definition.",
+				"Acids increase the concentration of H+ in water."));
+		questions.add(withHints(sampleNumeric(-1021L, -119L,
+				"What is the pH of a solution with [H+] = 1.0E-3 M?", "3.0", ""),
+				"pH = -log[H+].",
+				"-log(1.0E-3) equals 3.0."));
+		questions.add(withHints(sampleMultipleChoice(-1022L, -120L,
+				"What happens when Qsp is greater than Ksp?",
+				List.of("more solute dissolves", "a precipitate forms", "nothing can happen", "the solution is unsaturated"), "b"),
+				"Compare the ion product with the solubility limit.",
+				"If Qsp exceeds Ksp, ions must leave solution as a solid."));
+		questions.add(withHints(sampleMultipleChoice(-1023L, -121L,
+				"A spontaneous process at constant temperature and pressure has which sign for delta G?",
+				List.of("positive", "negative", "zero only", "always positive infinity"), "b"),
+				"Use Gibbs free energy as the spontaneity criterion.",
+				"Spontaneous processes have delta G less than zero."));
+		questions.add(withHints(sampleMultipleChoice(-1024L, -122L,
+				"Oxidation is best described as what?",
+				List.of("gain of electrons", "loss of electrons", "gain of protons", "loss of neutrons"), "b"),
+				"Remember OIL RIG.",
+				"Oxidation Is Loss of electrons."));
+		questions.add(withHints(sampleMultipleChoice(-1025L, -123L,
+				"What particle is emitted in beta-minus decay?",
+				List.of("electron", "proton", "neutron", "alpha particle"), "a"),
+				"Beta-minus decay converts a neutron into a proton.",
+				"An electron is emitted in beta-minus decay."));
+		questions.add(withHints(sampleMultipleChoice(-1026L, -124L,
+				"Which formula represents methane?",
+				List.of("CH4", "C2H6", "CH3OH", "CO2"), "a"),
+				"Methane is the simplest alkane.",
+				"Alkanes follow CnH2n+2; for n=1, the formula is CH4."));
+		return questions;
+	}
+
+	private Question withHints(Question q,String... hints) {
+		q.hint = String.join("||", hints);
+		return q;
+	}
+
+	private Question sampleMultipleChoice(long id,long conceptId,String text,List<String> choices,String correctAnswer) {
+		Question q = sampleQuestionBase(id, conceptId, Question.MULTIPLE_CHOICE, text, correctAnswer);
+		q.nChoices = choices.size();
+		q.choices = new ArrayList<>(choices);
+		return q;
+	}
+
+	private Question sampleTrueFalse(long id,long conceptId,String text,boolean correctAnswer) {
+		return sampleQuestionBase(id, conceptId, Question.TRUE_FALSE, text, correctAnswer?"true":"false");
+	}
+
+	private Question sampleSelectMultiple(long id,long conceptId,String text,List<String> choices,String correctAnswer) {
+		Question q = sampleQuestionBase(id, conceptId, Question.SELECT_MULTIPLE, text, correctAnswer);
+		q.nChoices = choices.size();
+		q.choices = new ArrayList<>(choices);
+		return q;
+	}
+
+	private Question sampleFillInWord(long id,long conceptId,String text,String correctAnswer) {
+		Question q = sampleQuestionBase(id, conceptId, Question.FILL_IN_WORD, text, correctAnswer);
+		q.strictSpelling = false;
+		return q;
+	}
+
+	private Question sampleNumeric(long id,long conceptId,String text,String correctAnswer,String units) {
+		Question q = sampleQuestionBase(id, conceptId, Question.NUMERIC, text, correctAnswer);
+		q.requiredPrecision = 2.0;
+		q.significantFigures = 0;
+		q.tag = units;
+		return q;
+	}
+
+	private Question sampleQuestionBase(long id,long conceptId,int type,String text,String correctAnswer) {
+		Question q = new Question(type);
+		q.id = id;
+		q.conceptId = conceptId;
+		q.assignmentType = "Quiz";
+		q.text = text;
+		q.correctAnswer = correctAnswer;
+		q.pointValue = 1;
+		q.parameterString = "";
+		q.hint = "";
+		q.solution = "";
+		q.tag = "";
+		q.nChoices = 0;
+		q.requiredPrecision = 0.0;
+		q.significantFigures = 0;
+		q.isActive = true;
+		return q;
+	}
+
+	private boolean isVisitorQuestion(Question q) {
+		if (q == null || q.id == null || q.type == null || q.assignmentType == null || q.hasNoCorrectAnswer()) return false;
+		if (!"Quiz".equals(q.assignmentType) && !"Homework".equals(q.assignmentType)) return false;
+		int questionType = q.getQuestionType();
+		return questionType > 0 && questionType < 6;
+	}
+
+	private List<Concept> loadConcepts() {
+		List<Concept> allConcepts = ofy().load().type(Concept.class).order("orderBy").list();
+		List<Concept> publicConcepts = new ArrayList<>();
+		for (Concept c : allConcepts) if (isPublicConcept(c)) publicConcepts.add(c);
+		return publicConcepts;
+	}
+
+	private boolean isPublicConcept(Concept c) {
+		if (c == null || c.id == null || c.title == null || c.title.isBlank()) return false;
+		return c.orderBy == null || !c.orderBy.startsWith(" 0");
+	}
+
+	private Map<Long, Concept> conceptMap(List<Concept> concepts) {
+		Map<Long, Concept> conceptMap = new HashMap<>();
+		for (Concept c : concepts) if (c.id != null) conceptMap.put(c.id, c);
+		return conceptMap;
+	}
+
+	private String conceptTitle(Map<Long,Concept> conceptMap,Long conceptId) {
+		if (conceptId == null) return "";
+		Concept c = conceptMap.get(conceptId);
+		return c == null || c.title == null?"":c.title;
+	}
+
+	private int requestedQuestionCount(HttpServletRequest request) {
+		int nQuestions = (int) parseLong(request.getParameter("n"), DEFAULT_QUESTION_COUNT);
+		if (nQuestions < 1) return 1;
+		return Math.min(nQuestions, MAX_QUESTION_COUNT);
+	}
+
+	private Long requestedConceptId(HttpServletRequest request) {
+		try {
+			String value = request.getParameter("ConceptId");
+			if (value == null || value.isBlank()) return null;
+			long conceptId = Long.parseLong(value);
+			return conceptId == 0L?null:conceptId;
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	private String newQuestionUrl(Long conceptId,int count) {
+		String url = "/example-questions?n=" + Math.max(1, Math.min(count, MAX_QUESTION_COUNT));
+		if (conceptId != null) url += "&ConceptId=" + conceptId;
+		return url;
+	}
+
+	private long parseLong(String value,long defaultValue) {
+		try {
+			return Long.parseLong(value);
+		} catch (Exception e) {
+			return defaultValue;
+		}
+	}
+
+	private String orderResponses(String[] answers) {
+		if (answers == null || answers.length == 0) return "";
+		Arrays.sort(answers);
+		String studentAnswer = "";
+		for (String answer : answers) if (answer != null) studentAnswer += answer;
+		return studentAnswer;
+	}
+
+	private String html(String s) {
+		if (s == null) return "";
+		return s.replace("&", "&amp;")
+				.replace("<", "&lt;")
+				.replace(">", "&gt;")
+				.replace("\"", "&quot;")
+				.replace("'", "&#39;");
+	}
+
+	private String studentAnswerHtml(String s) {
+		if (s == null) return "";
+		return s.replace("<", "&lt;").replace(">", "&gt;");
+	}
+}

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -135,7 +135,8 @@
               <h3 class="h5">Students rate ChemVantage:</h3>
               <img src="https://images.chemvantage.org/marketing/5stars.png" alt="ChemVantage rating" />&nbsp;4.3 out of 5 stars (12463 ratings)<br/>
             </div>
-            <div class="p-4 bg-white border rounded-3 h-100 d-flex" style="margin-top:20px;justify-content:space-evenly;">
+            <div class="p-4 bg-white border rounded-3 h-100 d-flex flex-wrap gap-2" style="margin-top:20px;justify-content:space-evenly;">
+              <a class="btn btn-outline-primary" href="/example-questions">Example Questions</a>
               <button class="btn btn-primary" id="launch-homework">Sample Homework</button> 
               <button class="btn btn-primary" id="launch-quiz">Sample Quiz</button> 
               <button class="btn btn-primary" id="launch-video">Sample Video</button>

--- a/src/main/webapp/sampleQuestionLibrary.json
+++ b/src/main/webapp/sampleQuestionLibrary.json
@@ -1,0 +1,7545 @@
+{
+    "generatedFrom":  "chem-vantage-hrd Datastore Concept and Question entities",
+    "generatedAt":  "2026-05-15T21:18:57Z",
+    "concepts":  [
+                     {
+                         "id":  6252694406955008,
+                         "orderBy":  " 0.1",
+                         "title":  "Essential Chemistry",
+                         "public":  false,
+                         "questions":  [
+                                           {
+                                               "id":  5068913299161088,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which two of the following compounds have a permanent dipole moment?",
+                                               "correctAnswer":  "be",
+                                               "choices":  [
+                                                               "BF\u003csub\u003e3\u003c/sub\u003e",
+                                                               "H\u003csub\u003e2\u003c/sub\u003eO",
+                                                               "Cl\u003csub\u003e2\u003c/sub\u003e",
+                                                               "CO\u003csub\u003e2\u003c/sub\u003e",
+                                                               "NH\u003csub\u003e3\u003c/sub\u003e"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5097885940580352,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which three of the following compounds have ionic bonds?",
+                                               "correctAnswer":  "acd",
+                                               "choices":  [
+                                                               "LiCl",
+                                                               "O\u003csub\u003e3\u003c/sub\u003e",
+                                                               "KMnO\u003csub\u003e3\u003c/sub\u003e",
+                                                               "CaF\u003csub\u003e2\u003c/sub\u003e",
+                                                               "N\u003csub\u003e2\u003c/sub\u003eO\u003csub\u003e5\u003c/sub\u003e"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5103447386357760,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "A substance that adopts part of the shape of its container but not its full volume is in the",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "liquid phase.",
+                                                               "solid phase.",
+                                                               "gas phase."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6205094358155264,
+                         "orderBy":  " 0.2",
+                         "title":  "Essential Math",
+                         "public":  false,
+                         "questions":  [
+                                           {
+                                               "id":  5073260812697600,
+                                               "type":  "NUMERIC",
+                                               "text":  "Evaluate the expression\u003cbr/\u003e\r\n#a#x + (|#b#|x|) + log\u003csub\u003e10\u003c/sub\u003e(#c#x) = \u003cbr/\u003e\r\nwhen the value of x is #d/10#",
+                                               "correctAnswer":  "a*d/10+b/(d/10)+log(c*d/10)",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "parameterString":  "a 2:5 b 31:49 c 80:99 d 71:99",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5078148485480448,
+                                               "type":  "NUMERIC",
+                                               "text":  "Evaluate the expression\u003cbr/\u003e\r\n(|#a#|7|) - (|#b#|11|) = ",
+                                               "correctAnswer":  "a/7-b/11",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "parameterString":  "a 3:13 b 4:21",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5096384916619264,
+                                               "type":  "NUMERIC",
+                                               "text":  "If the following equations are both true, what is the value of x?\u003cbr/\u003ey + #a# = #b#x\u003cbr/\u003ex + y = #c#",
+                                               "correctAnswer":  "(c+a)/(1+b)",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "parameterString":  "a 4:9 b 3:4 c 11:14",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6293843616202752,
+                         "orderBy":  " 0.3",
+                         "title":  "Word Problems",
+                         "public":  false,
+                         "questions":  [
+                                           {
+                                               "id":  4834437277155328,
+                                               "type":  "NUMERIC",
+                                               "text":  "If you walk a dog twice each day, and the average length of each walk is a quarter mile, what is the total distance walked in #a# weeks?",
+                                               "correctAnswer":  "a*7*2*0.25",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "miles",
+                                               "parameterString":  "a 5:19",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5129713862836224,
+                                               "type":  "NUMERIC",
+                                               "text":  "A recipe that normally makes 10 pancakes calls for (|3|4|) cup of milk. You adjust the recipe to make #a*10+5# pancakes instead. How much milk do you need for the larger batch?",
+                                               "correctAnswer":  "3/4*(a*10+5)/10",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "cups",
+                                               "parameterString":  "a 1:4",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5147969797488640,
+                                               "type":  "NUMERIC",
+                                               "text":  "Janet\u0027s car gets an average of #a# miles per gallon of gasoline. If she drives her car for #b# minutes at 55.0 miles per hour, what is the cost of gasoline for this trip? Assume that the price of gasoline is $#c/100#/gallon. Round your answer to three significant digits.",
+                                               "correctAnswer":  "b/60*55/a*c/100",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  3,
+                                               "tag":  "dollars",
+                                               "parameterString":  "a 22:45 b 40:60 c 320:380",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6200195872456704,
+                         "orderBy":  " 0.5",
+                         "title":  "Hide",
+                         "public":  false,
+                         "questions":  [
+                                           {
+                                               "id":  92029,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which of the following are extensive properties of a substance?",
+                                               "correctAnswer":  "ad",
+                                               "choices":  [
+                                                               "volume",
+                                                               "density",
+                                                               "pressure",
+                                                               "mass",
+                                                               "temperature"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  98013,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Heisenberg\u0027s uncertainty principle sets an absolute lower bound on the product of uncertainties for the position and",
+                                               "correctAnswer":  "momentum,linear momentum",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  " of any particle.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  99018,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Most elements are classified as ",
+                                               "correctAnswer":  "metals, metallic",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " and can be found in the lower-left and middle portions of the Periodic Table of Elements.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6226937557286912,
+                         "orderBy":  " 0.6",
+                         "title":  "Comprehensive121",
+                         "public":  false,
+                         "questions":  [
+                                           {
+                                               "id":  4818116142170112,
+                                               "type":  "NUMERIC",
+                                               "text":  "Calculate the density of helium gas at #a# K and #b*100# Pa.",
+                                               "correctAnswer":  "b*100/8.314/a/1000*4",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "tag":  "g/L",
+                                               "parameterString":  "a 201:299 b 820:990",
+                                               "solution":  "molar density n/V = P/(RT) = (|#b*100# Pa|8.314 J/mol-K) * #a# K|) = #b*100/8.314/a# mol/m\u003csup\u003e3\u003c/sup\u003e\u003cbr/\u003e\r\nConvert to g/L:\u003cbr/\u003e\r\n#b*100/8.314/a# mol/m\u003csup\u003e3\u003c/sup\u003e * (|1 m\u003csup\u003e3\u003c/sup\u003e|1000 L|) * (|4.003 g|1 mol He|) = #b*100/8.314/a/1000*4# g/L",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4821740356370432,
+                                               "type":  "NUMERIC",
+                                               "text":  "Find the empirical formula of an ionic compound that is #22.9898*100/(22.9898+35.453+a*15.999)#% Na, #35.453*100/(22.9898+35.453+a*15.999)#% Cl and #a*15.999*100/(22.9898+35.453+a*15.999)#% O by mass. Write the molar mass of the compound in the space below.",
+                                               "correctAnswer":  "22.9898+35.453+a*15.999",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "tag":  "g/mol",
+                                               "parameterString":  "a 1:4",
+                                               "solution":  "Step 1: Convert to g\u003cbr/\u003e\r\nNa: #22.9898*100/(22.9898+35.453+a*15.999)# g\u003cbr/\u003e\r\nCl: #35.453*100/(22.9898+35.453+a*15.999)# g\u003cbr/\u003e\r\nO:  #a*15.999*100/(22.9898+35.453+a*15.999)# g\u003cbr/\u003e\r\nStep 2: Convert to moles\u003cbr/\u003e\r\nNa: #22.9898*100/(22.9898+35.453+a*15.999)# g * (|1 mol|22.9898 g|) = #100/(22.9898+35.453+a*15.999)# mol\u003cbr/\u003e\r\nCl: #35.453*100/(22.9898+35.453+a*15.999)# g * (|1 mol|35.453 g|) = #100/(22.9898+35.453+a*15.999)# mol\u003cbr/\u003e\r\nO: #a*15.999*100/(22.9898+35.453+a*15.999)# g * (|1 mol|15.999 g|) = #a*100/(22.9898+35.453+a*15.999)# mol\u003cbr/\u003e\r\nStep 3: Write empirical formula with decimals\u003cbr/\u003e\r\nNa\u003csub\u003e#100/(22.9898+35.453+a*15.999)#\u003c/sub\u003eCl\u003csub\u003e#100/(22.9898+35.453+a*15.999)#\u003c/sub\u003eO\u003csub\u003e#a*100/(22.9898+35.453+a*15.999)#\u003c/sub\u003e\u003cbr/\u003e\r\nStep 4: Convert to integers\u003cbr/\u003e\r\nNa\u003csub\u003e1\u003c/sub\u003eCl\u003csub\u003e1\u003c/sub\u003eO\u003csub\u003e#a#\u003c/sub\u003e\u003cbr/\u003e\r\nMolar mass = #22.9898+35.453+a*15.999# g/mol\r\n",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4833496956928000,
+                                               "type":  "NUMERIC",
+                                               "text":  "If #a/10# mol ideal gas is confined to a #b# L container, what temperature is required for the pressure to be equal to 1.00 bar?",
+                                               "correctAnswer":  "1e5*b/1000/(a/10)/8.314",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  3,
+                                               "tag":  "K",
+                                               "parameterString":  "a 17:32 b 38:65",
+                                               "solution":  "Convert to SI units: V = #b/1000# m\u003csup\u003e3\u003c/sup\u003e and P = 1.00E5 Pa\u003cbr/\u003e\r\nT = PV/nR = 1.00E5 Pa * #b/1000# m\u003csup\u003e3\u003c/sup\u003e / (#a/10# mol * 8.314 J/mol-K) = #1e5*b/1000/(a/10)/8.314# K\u003cbr/\u003e\r\n",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6280819078594560,
+                         "orderBy":  " 0.7",
+                         "title":  "Trigonometry",
+                         "public":  false,
+                         "questions":  [
+                                           {
+                                               "id":  6193257311895552,
+                                               "type":  "NUMERIC",
+                                               "text":  "Convert (|#if(a,1,-1)*b#\u0026pi;|#if(b=3,2,3)#|) radians to degrees.",
+                                               "correctAnswer":  "if(a,1,-1)*b*180/if(b=3,2,3)",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "degrees",
+                                               "parameterString":  "a 0:1 b 2:5 ",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6230862233600000,
+                                               "type":  "NUMERIC",
+                                               "text":  "Find the angle, \u0026theta;, in the range -90\u0026deg; to +90\u0026deg; where cos(#45*a#\u0026deg;) = sin(\u0026theta;)",
+                                               "correctAnswer":  "90-a*45",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "degrees",
+                                               "parameterString":  "a 0:4",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6243339046486016,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Which of the following represents the value of cos(\u0026pi;/4)?",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "\u0026radic;2/2",
+                                                               "1",
+                                                               "0",
+                                                               "1/2",
+                                                               "\u0026radic;3/2"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6310428633464832,
+                         "orderBy":  " 0.8",
+                         "title":  "Essay Questions",
+                         "public":  false,
+                         "questions":  [
+                                           {
+                                               "id":  4536264931147776,
+                                               "type":  "ESSAY",
+                                               "text":  "Provide a step-by-step explanation of how to convert temperatures from Fahrenheit to Celsius and vice versa. Include a simple example for clarification.",
+                                               "correctAnswer":  "",
+                                               "hints":  [
+                                                             "Start by writing the two conversion formulas.",
+                                                             "Use C = (F - 32) x 5/9 and F = (C x 9/5) + 32."
+                                                         ]
+                                           },
+                                           {
+                                               "id":  4571449303236608,
+                                               "type":  "ESSAY",
+                                               "text":  "Explain the concept of density and provide a brief formula for calculating it. Why is density considered a crucial property in the field of chemistry?",
+                                               "correctAnswer":  "",
+                                               "hints":  [
+                                                             "Define density as a relationship between mass and volume.",
+                                                             "Use density = mass / volume, and connect it to identifying substances."
+                                                         ]
+                                           },
+                                           {
+                                               "id":  4606633675325440,
+                                               "type":  "ESSAY",
+                                               "text":  "Explain the Law of Conservation of Mass and its role in balancing chemical equations. Why is it crucial to ensure that the number of atoms on both sides of the equation is the same?",
+                                               "correctAnswer":  "",
+                                               "hints":  [
+                                                             "State what happens to atoms during a chemical reaction.",
+                                                             "Balanced equations show that atoms are rearranged, not created or destroyed."
+                                                         ]
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6294585807732736,
+                         "orderBy":  " 0.9",
+                         "title":  "Marketing",
+                         "public":  false,
+                         "questions":  [
+                                           {
+                                               "id":  6196310580658176,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Used in rechargeable batteries, this light element is also found in many rocks. Can you identify it?",
+                                               "correctAnswer":  "lithium, Li",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6201488499277824,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "This element is used in lightbulb filaments and is the highest melting and boiling point. Can you guess?",
+                                               "correctAnswer":  "tungsten, W",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6205506734784512,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Mercury is an unusual element because it is a liquid. What is the only other element that is liquid at room temperature?",
+                                               "correctAnswer":  "bromine, Br2, Br",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4793783732666368,
+                         "orderBy":  " 0.94",
+                         "title":  "Fires and Explosions",
+                         "public":  false,
+                         "questions":  [
+                                           {
+                                               "id":  4798913995603968,
+                                               "type":  "NUMERIC",
+                                               "text":  "Propane (C\u003csub\u003e3\u003c/sub\u003eH\u003csub\u003e8\u003c/sub\u003e) reacts with high pressure steam (H\u003csub\u003e2\u003c/sub\u003eO) to make carbon monoxide (CO) and hydrogen (H\u003csub\u003e2\u003c/sub\u003e). Write the balanced reaction for this process and calculate the number of grams of propane required to produce #a# moles of H\u003csub\u003e2\u003c/sub\u003e.",
+                                               "correctAnswer":  "a/7*44.1",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  "g C\u003csub\u003e3\u003c/sub\u003eH\u003csub\u003e8\u003c/sub\u003e",
+                                               "parameterString":  "a 6:19",
+                                               "solution":  "The balanced reaction is\u003cbr/\u003e\r\nC\u003csub\u003e3\u003c/sub\u003eH\u003csub\u003e8\u003c/sub\u003e + 3 H\u003csub\u003e2\u003c/sub\u003eO \u0026rarr; 3 CO + 7 H\u003csub\u003e2\u003c/sub\u003e\u003cbr/\u003e\r\nStarting point: #a# mol H\u003csub\u003e2\u003c/sub\u003e\u003cbr/\u003e\r\nGoal: g propane\u003cbr/\u003e\r\nPlan: mol H\u003csub\u003e2\u003c/sub\u003e \u0026rarr; mol propane \u0026rarr; g propane\u003cbr/\u003e\r\nMolar mass propane = 44.1 g/mol\u003cbr/\u003e\r\n#a# mol H\u003csub\u003e2\u003c/sub\u003e * (|1 mol propane|7 mol H\u003csub\u003e2\u003c/sub\u003e|) * (|44.1 g propane|1 mol propane|) = #a/7*44.1# g propane",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4889568004538368,
+                                               "type":  "NUMERIC",
+                                               "text":  "Calculate the change in enthalpy (\u0026Delta;H) for the reaction\u003cbr/\u003e\r\nC\u003csub\u003e3\u003c/sub\u003eH\u003csub\u003e8\u003c/sub\u003e + 3 H\u003csub\u003e2\u003c/sub\u003eO \u0026rarr; 3 CO + 7 H\u003csub\u003e2\u003c/sub\u003e\u003cbr/\u003e\r\nThe enthalpies of formation are\u003cbr/\u003e\r\n\u0026Delta;H\u003csub\u003ef\u003c/sub\u003e[C\u003csub\u003e3\u003c/sub\u003eH\u003csub\u003e8\u003c/sub\u003e] = -103.8 kJ/mol\u003cbr/\u003e\r\n\u0026Delta;H\u003csub\u003ef\u003c/sub\u003e[H\u003csub\u003e2\u003c/sub\u003eO] = -241.82 kJ/mol\u003cbr/\u003e\r\n\u0026Delta;H\u003csub\u003ef\u003c/sub\u003e[CO] = -110.52 kJ/mol\u003cbr/\u003e\r\n\u0026Delta;H\u003csub\u003ef\u003c/sub\u003e[H\u003csub\u003e2\u003c/sub\u003e] = 0 kJ/mol\u003cbr/\u003e\r\nHow much heat input is required to generate #a# moles of H\u003csub\u003e2\u003c/sub\u003e?",
+                                               "correctAnswer":  "a*497.7/7",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  "kJ",
+                                               "parameterString":  "a 8:19",
+                                               "solution":  "\u0026Delta;H\u003csub\u003erxn\u003c/sub\u003e = \u0026Delta;H\u003csub\u003ef\u003c/sub\u003e(products) - \u0026Delta;H\u003csub\u003ef\u003c/sub\u003e(reactants) = [3*(-110.52) + 7*0] - [-103.8 + 3*(-241.82)] = +497.7 kJ/mol\u003cbr/\u003e\r\n#a# mol H\u003csub\u003e2\u003c/sub\u003e * (|497.7 kJ|7 mol H\u003csub\u003e2\u003c/sub\u003e|) = #a*497.7/7# kJ",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4892810716643328,
+                                               "type":  "NUMERIC",
+                                               "text":  "Balance the following combustion reaction to determine the stoichiometric coefficient for oxygen. In other words, what is the value of \u003ci\u003ex\u003c/i\u003e in the equation below?\u003cbr/\u003e\r\nC\u003csub\u003e#a+2*b#\u003c/sub\u003eH\u003csub\u003e#4*(b+c)#\u003c/sub\u003eO\u003csub\u003e2\u003c/sub\u003e + \u003ci\u003ex\u003c/i\u003e O\u003csub\u003e2\u003c/sub\u003e \u0026rarr; ? CO\u003csub\u003e2\u003c/sub\u003e + ? H\u003csub\u003e2\u003c/sub\u003eO",
+                                               "correctAnswer":  "#a+2*b+b+c-1#",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "moles O\u003csub\u003e2\u003c/sub\u003e",
+                                               "parameterString":  "a 3:4 b 0:1 c 1:2",
+                                               "solution":  "Each mole of C\u003csub\u003e#a+2*b#\u003c/sub\u003eH\u003csub\u003e#4*(b+c)#\u003c/sub\u003eO\u003csub\u003e2\u003c/sub\u003e produces #a+2*b# moles of CO\u003csub\u003e2\u003c/sub\u003e and #2*(b+c)# moles of H\u003csub\u003e2\u003c/sub\u003eO\u003cbr/\u003e\r\nThis gives the partially balanced reaction:\u003cbr/\u003e\r\nC\u003csub\u003e#a+2*b#\u003c/sub\u003eH\u003csub\u003e#4*(b+c)#\u003c/sub\u003eO\u003csub\u003e2\u003c/sub\u003e + \u003ci\u003ex\u003c/i\u003e O\u003csub\u003e2\u003c/sub\u003e \u0026rarr; #a+2*b# CO\u003csub\u003e2\u003c/sub\u003e + #2*(b+c)# H\u003csub\u003e2\u003c/sub\u003eO\u003cbr/\u003e\r\nThere are #2*(a+2*b)+2*(b+c)# moles of O atoms on the products side, and 2 moles of O atoms on the reactants side (in the fuel), so we need to provide #2*(a+2*b)+2*(b+c)-2# moles of O atoms or #a+2*b+b+c-1# moles of O\u003csub\u003e2\u003c/sub\u003e on the reactant side to balance the reaction:\u003cbr/\u003e\r\nC\u003csub\u003e#a+2*b#\u003c/sub\u003eH\u003csub\u003e#4*(b+c)#\u003c/sub\u003eO\u003csub\u003e2\u003c/sub\u003e + #a+2*b+b+c-1# O\u003csub\u003e2\u003c/sub\u003e \u0026rarr; #a+2*b# CO\u003csub\u003e2\u003c/sub\u003e + #2*(b+c)# H\u003csub\u003e2\u003c/sub\u003eO",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6194287498231808,
+                         "orderBy":  " 1.1",
+                         "title":  "Scientific Method",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  92028,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Traditionally, chemists have studied chemical transformations in the following two ways:",
+                                               "correctAnswer":  "ad",
+                                               "choices":  [
+                                                               "analysis (taking things apart)",
+                                                               "alchemy (turning lead into gold)",
+                                                               "expansion (making things bigger)",
+                                                               "synthesis (putting things together)",
+                                                               "contraction (making things smaller)"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  92033,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "In the scientific method, a tentative explanation for a set of observations that can be subjected to experimental tests is called a",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "theory",
+                                                               "mathematical model",
+                                                               "scientific law",
+                                                               "hypothesis",
+                                                               "scientific principle"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  99020,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The scientific",
+                                               "correctAnswer":  "method",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "is an approach that allows the continuous refinement of scientific laws, hypotheses, and theories by subjecting them to experimental tests.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4847460597366784,
+                         "orderBy":  " 1.2a",
+                         "title":  "Atoms \u0026 Molecules",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  98015,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "John Dalton\u0027s Law of",
+                                               "correctAnswer":  "Multiple",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "Proportions states that if two elements form more than one compound between them, then the ratios of the masses of the second element which combine with a fixed mass of the first element will be ratios of small whole numbers. This is the one of the most basic laws of stoichiometry.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  106015,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Elements in the periodic table have been named in honor of",
+                                               "correctAnswer":  "abcde",
+                                               "choices":  [
+                                                               "scientists",
+                                                               "cities",
+                                                               "planets",
+                                                               "continents",
+                                                               "countries"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  107020,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which of the following formulas represent molecular elements?",
+                                               "correctAnswer":  "abe",
+                                               "choices":  [
+                                                               "S\u003csub\u003e8\u003c/sub\u003e",
+                                                               "O\u003csub\u003e2\u003c/sub\u003e",
+                                                               "He",
+                                                               "H\u003csub\u003e2\u003c/sub\u003eO",
+                                                               "P\u003csub\u003e4\u003c/sub\u003e"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6256866581020672,
+                         "orderBy":  " 1.2b",
+                         "title":  "Phases \u0026 Classification of Matter",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  142029,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Any pure substance that can be decomposed into simpler substances by chemical processes is known as a(n)",
+                                               "correctAnswer":  "c",
+                                               "choices":  [
+                                                               "atom",
+                                                               "polymer",
+                                                               "compound",
+                                                               "mixture",
+                                                               "material"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  142030,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "In any chemical reaction the mass of the products is always",
+                                               "correctAnswer":  "c",
+                                               "choices":  [
+                                                               "greater than the mass of the reactants",
+                                                               "less than the mass of the reactants",
+                                                               "the same as the mass of the reactants",
+                                                               "either greater than or less than the reactants depending on temperature",
+                                                               "unknown"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  161008,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "A liquid is a phase of matter that",
+                                               "correctAnswer":  "bc",
+                                               "choices":  [
+                                                               "has a definite shape",
+                                                               "adopts the shape of its container",
+                                                               "has a definite volume",
+                                                               "adopts the volume of its container",
+                                                               "has weak intermolecular forces"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6269810203164672,
+                         "orderBy":  " 1.3",
+                         "title":  "Physical \u0026 Chemical Properties",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  92032,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Which of the following molecules is the active ingredient in household chlorine bleach?",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "O\u003csub\u003e2\u003c/sub\u003e",
+                                                               "H\u003csub\u003e2\u003c/sub\u003eO\u003csub\u003e2\u003c/sub\u003e",
+                                                               "H\u003csub\u003e2\u003c/sub\u003eO",
+                                                               "NaOCl",
+                                                               "NaCl"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  92034,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "An example of a chemical change is",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "mixing sand with water",
+                                                               "evaporation of alcohol",
+                                                               "distillation of water",
+                                                               "combustion of gasoline",
+                                                               "dissolving sugar in water"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  109026,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which two chemical elements are liquids at room temperature and atmospheric pressure?",
+                                               "correctAnswer":  "ae",
+                                               "choices":  [
+                                                               "bromine",
+                                                               "lithium",
+                                                               "neon",
+                                                               "xenon",
+                                                               "mercury"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6230914979332096,
+                         "orderBy":  " 1.4a",
+                         "title":  "Units, Prefixes \u0026 Conversions",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  99019,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "In the International System of Units (SI), the fundamental unit of length is the",
+                                               "correctAnswer":  "meter, m",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  108018,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which three of the following are \u003ci\u003ederived\u003c/i\u003e SI units.",
+                                               "correctAnswer":  "acd",
+                                               "choices":  [
+                                                               "volume (m\u003csup\u003e3\u003c/sup\u003e)",
+                                                               "temperature (K)",
+                                                               "speed (m/s)",
+                                                               "concentration (mol/L)",
+                                                               "mass (kg)"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  126015,
+                                               "type":  "NUMERIC",
+                                               "text":  "Convert #a# L to cubic meters.",
+                                               "correctAnswer":  "0.001*a",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  3,
+                                               "tag":  "m\u003csup\u003e3\u003c/sup\u003e",
+                                               "parameterString":  "a 12:99",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6310094983135232,
+                         "orderBy":  " 1.4b",
+                         "title":  "Density",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  195007,
+                                               "type":  "NUMERIC",
+                                               "text":  "If a sample of unknown substance has a mass of #a/10# kg and a volume of #b/10# L, what is the density of the substance when expressed in g/cm\u003csup\u003e3\u003c/sup\u003e?",
+                                               "correctAnswer":  "a/b",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  3,
+                                               "tag":  "g/cm\u003csup\u003e3\u003c/sup\u003e",
+                                               "parameterString":  "a 30:40 b 10:20",
+                                               "solution":  "#a/10# kg = #a*100# g\u003cbr\u003e\r\n#b/10# L = #b*100# cm\u003csup\u003e3\u003c/sup\u003e\u003cbr\u003e\r\nDensity = mass/volume = #a*100# g / (#b*100# cm\u003csup\u003e3\u003c/sup\u003e) = #a/b# g/cm\u003csup\u003e3\u003c/sup\u003e",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  937499,
+                                               "type":  "NUMERIC",
+                                               "text":  "If a metal alloy has a density of #a/100# g/cm\u003csup\u003e3\u003c/sup\u003e, what is the volume of a #b/100# kg sample of the metal?",
+                                               "correctAnswer":  "b/100/(a*10)*1e6",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  3,
+                                               "tag":  "cm\u003csup\u003e3\u003c/sup\u003e",
+                                               "parameterString":  "a 115:700 b 50:200",
+                                               "solution":  "First convert kg to g:  mass = #b/100# kg = #b*10# g\u003cbr\u003e\r\nThe volume of the sample is given by mass divided by density:\u003cbr\u003e\r\nV = (#b*10# g) / (#a/100# g/cm\u003csup\u003e3\u003c/sup\u003e) = #b*10/(a/100)# cm\u003csup\u003e3\u003c/sup\u003e",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  1552002,
+                                               "type":  "NUMERIC",
+                                               "text":  "If a sample of unknown substance has a mass of #a/10# kg and a volume of #b/10# L, what is the density of the substance when expressed in conventional (but non-SI) units of g/cm\u003csup\u003e3\u003c/sup\u003e?",
+                                               "correctAnswer":  "a/b",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  3,
+                                               "tag":  "g/cm\u003csup\u003e3\u003c/sup\u003e",
+                                               "parameterString":  "a 30:40 b 10:20",
+                                               "solution":  "#a/10# kg = #100*a# g\u003cbr\u003e\r\n#b/10# L = #b*100# cm\u003csup\u003e3\u003c/sup\u003e\u003cbr\u003e\r\ndensity = (#100*a# g) / (#b*100# cm\u003csup\u003e3\u003c/sup\u003e) = #a/b# g/cm\u003csup\u003e3\u003c/sup\u003e",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6035491685662720,
+                         "orderBy":  " 1.5a",
+                         "title":  "Uncertainty, Accuracy \u0026 Precision",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  139017,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The introduction of systematic error in a measurement will result in decreased",
+                                               "correctAnswer":  "accuracy",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  ", even if the precision is high.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  178014,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "An increase in random error will decrease the ",
+                                               "correctAnswer":  "precision, reproducibility",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  "of a set of measurements, but generally will not affect the accuracy.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  1546004,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The introduction of systematic error in a measurement will result in decreased",
+                                               "correctAnswer":  "accuracy",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  ", even if the precision is high.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6192740722802688,
+                         "orderBy":  " 1.5b",
+                         "title":  "Significant Figures",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  143024,
+                                               "type":  "NUMERIC",
+                                               "text":  "How many significant digits are in the number #a/1000+b/10000# x 10\u003csup\u003e#c#\u003c/sup\u003e?",
+                                               "correctAnswer":  "5",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "parameterString":  "a 1000:9999 b 1:9 c 4:19",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  143025,
+                                               "type":  "NUMERIC",
+                                               "text":  "How many significant figures are in the number #a/1e3 + b/1e5#?",
+                                               "correctAnswer":  "5",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "parameterString":  "a 100:999 b 1:9",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5822740,
+                                               "type":  "NUMERIC",
+                                               "text":  "How many significant figures are in the number 0.00#a#b#?",
+                                               "correctAnswer":  "3",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "parameterString":  "a 23:98 b 0:2",
+                                               "solution":  "This number has 3 significant figures.  Leading zeros and the placement of the decimal point do not affect the number of significant figures.  However, trailing zeros are meaningful when present.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6321010189533184,
+                         "orderBy":  " 1.6a",
+                         "title":  "Dimensional Analysis",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  143026,
+                                               "type":  "NUMERIC",
+                                               "text":  "If the gravitational acceleration g is 9.8 m s\u003csup\u003e-2\u003c/sup\u003e, how much upward force must be applied to a #a*0.1# kg mass to prevent it from falling if the object is initially at rest?",
+                                               "correctAnswer":  "a*0.1*9.8",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  2,
+                                               "tag":  "Newtons",
+                                               "parameterString":  "a 11:24",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5822757,
+                                               "type":  "NUMERIC",
+                                               "text":  "If the price of electricity is $0.08 per kilowatt-hour, how much electrical energy can you purchase for $#a#?",
+                                               "correctAnswer":  "3.6e6*a/0.08",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  "J",
+                                               "parameterString":  "a 21:59",
+                                               "solution":  "1 kilowatt-hour = 3600000 J = 3.6E6 J\u003cbr\u003e\r\n3.6E6 J/kW\u0026middot;hr * $#a# / ($0.08 /kW\u0026middot;hr) = #3.6e6*a/0.08# J",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4827650100559872,
+                                               "type":  "NUMERIC",
+                                               "text":  "Convert #a/10# cubic ft to cubic meters.\u003cbr/\u003e\r\n1 m = 3.28084 ft.",
+                                               "correctAnswer":  "a/10/3.28084/3.28084/3.28084",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  3,
+                                               "tag":  "m\u003csup\u003e3\u003c/sup\u003e",
+                                               "parameterString":  "a 601:999",
+                                               "solution":  "#a/10# ft\u003csup\u003e3\u003c/sup\u003e * (|1 m|3.28084 ft|) * (|1 m|3.28084 ft|) * (|1 m|3.28084 ft|) = #a/10/3.28084/3.28084/3.28084# m\u003csup\u003e3\u003c/sup\u003e",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  5983808951681024,
+                         "orderBy":  " 1.6b",
+                         "title":  "Temperature Conversions",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  175012,
+                                               "type":  "NUMERIC",
+                                               "text":  "On the Celsius temperature scale, the normal boiling point of water is",
+                                               "correctAnswer":  "100",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "C.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  180024,
+                                               "type":  "NUMERIC",
+                                               "text":  "Convert #a*10# C to absolute temperature (kelvins).",
+                                               "correctAnswer":  "a*10+273",
+                                               "choices":  "",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "tag":  "K",
+                                               "parameterString":  "a -20:20",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  202005,
+                                               "type":  "NUMERIC",
+                                               "text":  "What is the freezing point of water, expressed in Kelvins?",
+                                               "correctAnswer":  "273.15",
+                                               "choices":  "",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "tag":  "K",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6239294326308864,
+                         "orderBy":  " 2.1",
+                         "title":  "Dalton\u0027s Atomic Theory",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  126014,
+                                               "type":  "NUMERIC",
+                                               "text":  "According to the law of multiple proportions, if #a# g of hydrogen combines with #8*a# g of oxygen to form water, then the amount of oxygen required to combine with #b# g of hydrogen to make hydrogen peroxide (H\u003csub\u003e2\u003c/sub\u003eO\u003csub\u003e2\u003c/sub\u003e) is ",
+                                               "correctAnswer":  "16*b",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  3,
+                                               "tag":  "g",
+                                               "parameterString":  "a 2:5 b 2:5",
+                                               "solution":  "The mass of two H atoms is 2 amu, and the mass of one O atom is 16 amu, Therefore, the mass ratio O:H in water is 8:1 and in hydrogen peroxide is 16:1.  To make hydrogen peroxide with #b# g of hydrogen requires 16 * #b# = #16*b# g of oxygen.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  175011,
+                                               "type":  "NUMERIC",
+                                               "text":  "Synthesis of #a*2# mol of NH\u003csub\u003e3\u003c/sub\u003e requires #a# mol of N\u003csub\u003e2\u003c/sub\u003e to react with",
+                                               "correctAnswer":  "3*a",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  3,
+                                               "tag":  "mol of H\u003csub\u003e2\u003c/sub\u003e.",
+                                               "parameterString":  "a 2:4",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  176018,
+                                               "type":  "NUMERIC",
+                                               "text":  "Synthesis of #a# mol of PCl\u003csub\u003e5\u003c/sub\u003e requires the reaction of #a# mol of P with ",
+                                               "correctAnswer":  "a*3/2",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  3,
+                                               "tag":  "mol of Cl\u003csub\u003e2\u003c/sub\u003e.",
+                                               "parameterString":  "a 2:5",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6195158973939712,
+                         "orderBy":  " 2.2a",
+                         "title":  "Discovery of the Electron",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  148016,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "In 1909, Robert Millikan determined the electric charge of the electron by suspending charged droplets of",
+                                               "correctAnswer":  "oil",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "in an applied electric field.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  186026,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "By conducting experiments on cathode rays, J. J. Thompson discovered the",
+                                               "correctAnswer":  "electron, electrons",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  190002,
+                                               "type":  "NUMERIC",
+                                               "text":  "In the late 1800s, J.J. Thompson used a cathode ray tube to show that the electron has a mass that is approximately",
+                                               "correctAnswer":  "1823",
+                                               "choices":  "",
+                                               "requiredPrecision":  10,
+                                               "significantFigures":  0,
+                                               "tag":  "times less than that of hydrogen, the lightest known atom.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  5938901226618880,
+                         "orderBy":  " 2.2b",
+                         "title":  "Rutherford Scattering",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  202020,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Ernest Rutherford showed that the structure of atoms is not homogeneous. Rather, the positive charge is concentrated in a tiny nucleus. The remainder of the atoms is composed of mostly",
+                                               "correctAnswer":  "empty space,free space,space,vacuum,nothing",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  "throughout which tiny electrons are dispersed.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5699119151579136,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Ernest Rutherford\u0027s experiments with scattering alpha particles from gold foil led to which two of the following conclusions?",
+                                               "correctAnswer":  "bd",
+                                               "choices":  [
+                                                               "oil droplets can be levitated in an electric field",
+                                                               "a tiny positively charged nucleus lies at the center of every atom",
+                                                               "the ratio of atoms in each molecule must be a ratio of small integers",
+                                                               "the volume of every atom is almost entirely empty space",
+                                                               "metallic substances have electrons that are delocalized among many atoms"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6209821065084928,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The unexpected deflection of some alpha particles in Rutherford\u0027s experiment contradicted the _________ model of the atom.",
+                                               "correctAnswer":  "plum pudding",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4899319266410496,
+                         "orderBy":  " 2.2c",
+                         "title":  "Atomic Structure",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  108016,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The three basic types of subatomic particles are:",
+                                               "correctAnswer":  "acd",
+                                               "choices":  [
+                                                               "electrons",
+                                                               "gravitons",
+                                                               "protons",
+                                                               "neutrons",
+                                                               "neutrinos"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  111020,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The neutron has the following properties",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "mass = 1 amu, charge = +1",
+                                                               "mass = 1 amu, charge = 0",
+                                                               "mass = 1 amu, charge = -1",
+                                                               "mass = 0.00055 amu, charge = +1",
+                                                               "mass = 0.00055 amu, charge = -1"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  111021,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The electron has the following properties",
+                                               "correctAnswer":  "e",
+                                               "choices":  [
+                                                               "mass = 1 amu, charge = +1",
+                                                               "mass = 1 amu, charge = 0",
+                                                               "mass = 1 amu, charge = -1",
+                                                               "mass = 0.00055 amu, charge = +1",
+                                                               "mass = 0.00055 amu, charge = -1"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6311724654788608,
+                         "orderBy":  " 2.3a",
+                         "title":  "Atomic Symbols",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  127015,
+                                               "type":  "NUMERIC",
+                                               "text":  "The atomic number of neon is 10, but the Ne\u003csup\u003e#a#+\u003c/sup\u003e cation has only",
+                                               "correctAnswer":  "10-a",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "electrons.",
+                                               "parameterString":  "a 2:9",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  164017,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Which symbol represents the atom having 24 protons and 29 neutrons in its nucleus?",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "\u003csup\u003e53\u003c/sup\u003eCr",
+                                                               "\u003csup\u003e61\u003c/sup\u003eSe",
+                                                               "\u003csup\u003e24\u003c/sup\u003eCu",
+                                                               "\u003csup\u003e53\u003c/sup\u003eI",
+                                                               "\u003csup\u003e29\u003c/sup\u003eCr"
+                                                           ],
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  164019,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "What is identity of an ion having 34 protons, 32 electrons and 40 neutrons?",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "\u003csup\u003e74\u003c/sup\u003eSe\u003csup\u003e2+\u003c/sup\u003e",
+                                                               "\u003csup\u003e42\u003c/sup\u003eGe\u003csup\u003e10+\u003c/sup\u003e",
+                                                               "\u003csup\u003e74\u003c/sup\u003eGe\u003csup\u003e2+\u003c/sup\u003e",
+                                                               "\u003csup\u003e74\u003c/sup\u003eMo\u003csup\u003e2+\u003c/sup\u003e",
+                                                               "\u003csup\u003e72\u003c/sup\u003eGe\u003csup\u003e2+\u003c/sup\u003e"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4811933080879104,
+                         "orderBy":  " 2.3b",
+                         "title":  "Isotopes and Average Mass",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  96020,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Atoms having the same number of protons, but different numbers of neutrons are called",
+                                               "correctAnswer":  "isotopes",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5686925236109312,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Any two isotopes of the same element are distinguished from each other by the number of ",
+                                               "correctAnswer":  "neutrons",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "contained in the nucleus of each atom.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5711909161533440,
+                                               "type":  "TRUE_FALSE",
+                                               "text":  "Two isotopes of the same element differ in mass but are chemically identical to each other.",
+                                               "correctAnswer":  "true",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6267985915805696,
+                         "orderBy":  " 2.5",
+                         "title":  "Periodic Table of Elements",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93021,
+                                               "type":  "NUMERIC",
+                                               "text":  "The maximum number of electrons that can occupy orbitals in the 5s shell is",
+                                               "correctAnswer":  "2",
+                                               "choices":  "",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "tag":  "electrons",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  95014,
+                                               "type":  "NUMERIC",
+                                               "text":  "The maximum number of electrons that can occupy orbitals in the 4d shell is",
+                                               "correctAnswer":  "10",
+                                               "choices":  "",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "tag":  "electrons",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  95020,
+                                               "type":  "NUMERIC",
+                                               "text":  "The number of electrons required to fill all of the orbitals in the 5f shell is",
+                                               "correctAnswer":  "14",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " electrons",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6270943487328256,
+                         "orderBy":  " 2.6",
+                         "title":  "Ionic and Covalent Compounds",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  98017,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The most common ion of O has the same electron configuration as ",
+                                               "correctAnswer":  "Ne, neon",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  109027,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which of the following are ionic compounds?",
+                                               "correctAnswer":  "ae",
+                                               "choices":  [
+                                                               "BaCO\u003csub\u003e3\u003c/sub\u003e",
+                                                               "H\u003csub\u003e2\u003c/sub\u003eO",
+                                                               "PH\u003csub\u003e3\u003c/sub\u003e",
+                                                               "C\u003csub\u003e2\u003c/sub\u003eH\u003csub\u003e2\u003c/sub\u003e",
+                                                               "CrI\u003csub\u003e3\u003c/sub\u003e"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  165018,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The most common ion of Br has the same electron configuration as",
+                                               "correctAnswer":  "Kr, krypton",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6325503664848896,
+                         "orderBy":  " 2.7",
+                         "title":  "Chemical Nomenclature",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93017,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The proper name for the compound CoCl\u003csub\u003e3\u003c/sub\u003e is",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "cobalt(III) chloride",
+                                                               "cobalt chloride",
+                                                               "cobalt(I) chloride",
+                                                               "cobalt trichloride",
+                                                               "trichlorocobalt"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  94012,
+                                               "type":  "NUMERIC",
+                                               "text":  "The base name \u0027pent\u0027 is appropriate for naming hydrocarbons with",
+                                               "correctAnswer":  "5",
+                                               "choices":  "",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "tag":  "carbon atoms.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  94013,
+                                               "type":  "NUMERIC",
+                                               "text":  "Dinitrogen pentoxide contains 2 nitrogen atoms and ",
+                                               "correctAnswer":  "5",
+                                               "choices":  "",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "tag":  "oxygen atoms.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6286305243168768,
+                         "orderBy":  " 3.1a",
+                         "title":  "The Mole \u0026 Avogadro\u0027s Number",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  144034,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The number of carbon atoms in exactly 12 g of \u003csup\u003e12\u003c/sup\u003eC is called",
+                                               "correctAnswer":  "Avogadro\u0027s,Avogadro,Avagadro\u0027s",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "number, and is approximately 6.022x10\u003csup\u003e23\u003c/sup\u003e.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  1555010,
+                                               "type":  "NUMERIC",
+                                               "text":  "The number of molecules (not moles) of H\u003csub\u003e2\u003c/sub\u003eO in #a# g of H\u003csub\u003e2\u003c/sub\u003eO is",
+                                               "correctAnswer":  "a/18.016*6.022E23",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  3,
+                                               "tag":  "molecules",
+                                               "parameterString":  "a 21:49",
+                                               "solution":  "#a# g / 18.016 g/mol * 6.022E23 molecules/mol = #a/18.016*6.022E23# molecules",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  1558012,
+                                               "type":  "NUMERIC",
+                                               "text":  "The number of molecules (not moles) of C\u003csub\u003e6\u003c/sub\u003eH\u003csub\u003e12\u003c/sub\u003eO\u003csub\u003e6\u003c/sub\u003e in 17.0 g of C\u003csub\u003e6\u003c/sub\u003eH\u003csub\u003e12\u003c/sub\u003eO\u003csub\u003e6\u003c/sub\u003e is",
+                                               "correctAnswer":  "5.68E+22",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  3,
+                                               "tag":  "molecules",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4918128781295616,
+                         "orderBy":  " 3.1b",
+                         "title":  "Mass, Moles and Particles",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93030,
+                                               "type":  "NUMERIC",
+                                               "text":  "How many moles of hydrogen gas are required to react with carbon monoxide to form 1.00 mol of CH\u003csub\u003e3\u003c/sub\u003eOH?",
+                                               "correctAnswer":  "2",
+                                               "choices":  "",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "tag":  "mol",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  94011,
+                                               "type":  "NUMERIC",
+                                               "text":  "The mass of #a# mol of He atoms is",
+                                               "correctAnswer":  "a*4.003",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  4,
+                                               "tag":  "g",
+                                               "parameterString":  "a 1:5",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  125013,
+                                               "type":  "NUMERIC",
+                                               "text":  "The molar mass of potassium bicarbonate is ",
+                                               "correctAnswer":  "100.118",
+                                               "choices":  "",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  "g",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6231842105065472,
+                         "orderBy":  " 3.1c",
+                         "title":  "Formula Mass",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93040,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The ",
+                                               "correctAnswer":  "formula",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "unit of an ionic compound is the smallest electrically neutral collection of ions and reflects the smallest whole-number ratio of ions.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  125011,
+                                               "type":  "NUMERIC",
+                                               "text":  "The molar mass of calcium carbonate is ",
+                                               "correctAnswer":  "100.1",
+                                               "choices":  "",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  "g/mol",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  193010,
+                                               "type":  "NUMERIC",
+                                               "text":  "The molar mass of calcium carbonate is ",
+                                               "correctAnswer":  "100.09",
+                                               "choices":  "",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  "g",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6262283541413888,
+                         "orderBy":  " 3.2",
+                         "title":  "Empirical \u0026 Molecular Formulas",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  170012,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "A molecular formula for a molecule represents",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "the relative number of atoms of each type.",
+                                                               "the actual number of atoms of each type.",
+                                                               "how the atoms in each molecule are connected to each other.",
+                                                               "the density and molar mass of the substance.",
+                                                               "a space-filling molecular model of the substance."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  173007,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "An empirical formula for a molecule represents",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "the relative number of atoms of each type.",
+                                                               "the actual number of atoms of each type.",
+                                                               "how the atoms in each molecule are connected to each other.",
+                                                               "the density and molar mass of the substance.",
+                                                               "a space-filling molecular model of the substance."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  200006,
+                                               "type":  "NUMERIC",
+                                               "text":  "The number of carbon atoms in the formula unit for calcium cyanide is",
+                                               "correctAnswer":  "2",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6247902380294144,
+                         "orderBy":  " 3.3",
+                         "title":  "Molarity",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  126016,
+                                               "type":  "NUMERIC",
+                                               "text":  "How much water must be added to #10*a# mL of a stock solution of #0.1*c*b# M NaCl to prepare a #0.1*b# M solution of NaCl?",
+                                               "correctAnswer":  "10*a*(c-1)",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  3,
+                                               "tag":  "mL",
+                                               "parameterString":  "a 1:5 b 2:6 c 2:5",
+                                               "solution":  "The number of moles of NaCl in #a*10# mL of stock solution is\u003cbr\u003e\r\n#0.1*c*b# mol/L x #10*a# mL / (1000 mL/L) = #0.1*c*b*10*a/1000# mol NaCl\u003cbr\u003e\r\nThe total volume of solution required to prepare a #0.1*b# M solution using this amount of NaCl is #0.1*c*b*10*a/1000# mol / (#0.1*b# M) = #c*10*a/1000# L or #c*10*a# mL\u003cbr\u003e\r\nTherefore, the extra volume of water required is #c*10*a# mL - #10*a# mL = #10*a*c-10*a# mL",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  127011,
+                                               "type":  "NUMERIC",
+                                               "text":  "What volume of #a*0.1# M HCl solution contains #b*a*0.01# moles of hydrochloric acid?",
+                                               "correctAnswer":  "0.1*b",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "tag":  "L",
+                                               "parameterString":  "a 3:12 b 2:5",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  127012,
+                                               "type":  "NUMERIC",
+                                               "text":  "What volume of #a*0.1# M NH\u003csub\u003e3\u003c/sub\u003e solution contains #b*a*0.01# moles of ammonia?",
+                                               "correctAnswer":  "0.1*b",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "tag":  "L",
+                                               "parameterString":  "a 3:12 b 2:5",
+                                               "solution":  "#b*a*0.01# mol NH\u003csub\u003e3\u003c/sub\u003e * (|1 L soln|#a*0.1# mol NH\u003csub\u003e3\u003c/sub\u003e|) = #0.1*b# L soln",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6268104698494976,
+                         "orderBy":  " 3.4",
+                         "title":  "Molality, PPM, PPB",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  6222774707683328,
+                                               "type":  "NUMERIC",
+                                               "text":  "A\u0026nbsp;#a# mL sample of water from the Chesapeake Bay was found to contain #b/100# g of sodium chloride. What is the salt concentration expressed in ppm by mass?",
+                                               "correctAnswer":  "b/100/a*1e6",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  3,
+                                               "tag":  "ppm NaCl",
+                                               "parameterString":  "a 230:730 b 130:290",
+                                               "solution":  "1 mL H2O = 1 g H2O\u003cbr/\u003e\r\nconc. NaCl = (|#b/100# g NaCl|#a# mL H2O|) * (|1 mL H2O|1 g H2O|) * (|1 ppm NaCl * 10\u003csup\u003e6\u003c/sup\u003e g H2O|1 g NaCl|) = #b/100/a*1e6# ppm NaCl",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false,
+                                               "hints":  "1 ppm = (|1 g solute|10\u003csup\u003e6\u003c/sup\u003e g solvent|)"
+                                           },
+                                           {
+                                               "id":  6235339936497664,
+                                               "type":  "NUMERIC",
+                                               "text":  "If #a/100# g of bromine (Br\u003csub\u003e2\u003c/sub\u003e) is dissolved in #b# g of carbon disulfide (CS\u003csub\u003e2\u003c/sub\u003e), what is the \u003ci\u003emolality\u003c/i\u003e of the solution?",
+                                               "correctAnswer":  "a/100/159.808/b*1000",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  3,
+                                               "tag":  "\u003ci\u003em\u003c/i\u003e",
+                                               "parameterString":  "a 220:499 b 121:350",
+                                               "solution":  "moles Br\u003csub\u003e2\u003c/sub\u003e = #a/100# g Br2 * (|1 mol Br2|159.808 g Br2|) = #a/100/159.808# mol Br\u003csub\u003e2\u003c/sub\u003e\u003cbr/\u003e\r\nmolality = (|#a/100/159.808# mol Br2|#b# g CS2|) * (|1 \u003ci\u003em\u003c/i\u003e*1000 g CS2|1 mol Br2|) = #a/100/159.808/b*1000# \u003ci\u003em\u003c/i\u003e",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false,
+                                               "hints":  "Molality is the number of moles of solute per 1000 g solvent."
+                                           },
+                                           {
+                                               "id":  6265648446963712,
+                                               "type":  "NUMERIC",
+                                               "text":  "If #a/100# g of caffeine (C\u003csub\u003e8\u003c/sub\u003eH\u003csub\u003e10\u003c/sub\u003eN\u003csub\u003e4\u003c/sub\u003eO\u003csub\u003e2\u003c/sub\u003e) is dissolved in #b# g of supercritical carbon dioxide (CO\u003csub\u003e2\u003c/sub\u003e), what is the \u003ci\u003emolality\u003c/i\u003e of the solution?",
+                                               "correctAnswer":  "a/100/194.19/b*1000",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  3,
+                                               "tag":  "\u003ci\u003em\u003c/i\u003e",
+                                               "parameterString":  "a 220:499 b 121:350",
+                                               "solution":  "moles caffeine = #a/100# g caf * (|1 mol caf|194.19 g caf|) = #a/100/194.19# mol caf\u003cbr/\u003e\r\nmolality = (|#a/100/194.19# mol caf|#b# g CO2|) * (|1 \u003ci\u003em\u003c/i\u003e*1000 g CO2|1 mol caf|) = #a/100/194.19/b*1000# \u003ci\u003em\u003c/i\u003e",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false,
+                                               "hints":  "Molality is the number of moles of solute per 1000 g solvent."
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6216866829172736,
+                         "orderBy":  " 4.1a",
+                         "title":  "Total \u0026 Net Ionic Equations",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  4804281361760256,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "When hydrochloric acid (a strong acid) and sodium bicarbonate (a soluble salt) are mixed together in water, carbon dioxide bubbles out of solution. Which chemical equation represents the \u003ci\u003emolecular equation\u003c/i\u003e for this reaction?",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "HCl\u003ci\u003e(aq)\u003c/i\u003e + NaHCO\u003csub\u003e3\u003c/sub\u003e\u003ci\u003e(aq)\u003c/i\u003e \u0026rarr; NaCl\u003ci\u003e(aq)\u003c/i\u003e + H\u003csub\u003e2\u003c/sub\u003eO\u003ci\u003e(l)\u003c/i\u003e + CO\u003csub\u003e2\u003c/sub\u003e\u003ci\u003e(g)\u003c/i\u003e",
+                                                               "H\u003csup\u003e+\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e + HCO\u003csub\u003e3\u003c/sub\u003e\u003csup\u003e-\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e \u0026rarr; CO\u003csub\u003e2\u003c/sub\u003e\u003ci\u003e(g)\u003c/i\u003e +  H\u003csub\u003e2\u003c/sub\u003eO\u003ci\u003e(l)\u003c/i\u003e",
+                                                               "H\u003csup\u003e+\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e + Cl\u003csup\u003e-\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e + Na\u003csup\u003e+\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e + HCO\u003csub\u003e3\u003c/sub\u003e\u003csup\u003e-\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e \u0026rarr; Na\u003csup\u003e+\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e + Cl\u003csup\u003e-\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e + CO\u003csub\u003e2\u003c/sub\u003e\u003ci\u003e(g)\u003c/i\u003e +  H\u003csub\u003e2\u003c/sub\u003eO\u003ci\u003e(l)\u003c/i\u003e"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4895410769887232,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "When sodium chloride is added to a solution of lead nitrate, PbCl\u003csub\u003e2\u003c/sub\u003e precipitates as a bright yellow solid. Which of the following represents the \u003ci\u003ecomplete ionic equation\u003c/i\u003e for this reaction?",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "2 NaCl(\u003ci\u003eaq\u003c/i\u003e) + Pb(NO\u003csub\u003e3\u003c/sub\u003e)\u003csub\u003e2\u003c/sub\u003e(\u003ci\u003eaq\u003c/i\u003e) \u0026rarr; 2 NaNO\u003csub\u003e3\u003c/sub\u003e(\u003ci\u003eaq\u003c/i\u003e) + PbCl\u003csub\u003e2\u003c/sub\u003e(\u003ci\u003es\u003c/i\u003e)",
+                                                               "2 Na\u003csup\u003e+\u003c/sup\u003e(\u003ci\u003eaq\u003c/i\u003e) + 2 Cl\u003csup\u003e-\u003c/sup\u003e(\u003ci\u003eaq\u003c/i\u003e) + Pb\u003csup\u003e2+\u003c/sup\u003e(\u003ci\u003eaq\u003c/i\u003e) + 2 NO\u003csub\u003e3\u003c/sub\u003e\u003csup\u003e-\u003c/sup\u003e(\u003ci\u003eaq\u003c/i\u003e) \u0026rarr; 2 Na\u003csup\u003e+\u003c/sup\u003e(\u003ci\u003eaq\u003c/i\u003e) + 2 NO\u003csub\u003e3\u003c/sub\u003e\u003csup\u003e-\u003c/sup\u003e(\u003ci\u003eaq\u003c/i\u003e) + PbCl\u003csub\u003e2\u003c/sub\u003e(\u003ci\u003es\u003c/i\u003e)",
+                                                               "Pb\u003csup\u003e2+\u003c/sup\u003e(\u003ci\u003eaq\u003c/i\u003e) + 2 Cl\u003csup\u003e-\u003c/sup\u003e(\u003ci\u003eaq\u003c/i\u003e) \u0026rarr; PbCl\u003csub\u003e2\u003c/sub\u003e(\u003ci\u003es\u003c/i\u003e)"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5714960417030144,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "When hydrochloric acid (a strong acid) and sodium bicarbonate (a soluble salt) are mixed together in water, carbon dioxide bubbles out of solution. Which chemical equation represents the \u003ci\u003enet ionic equation\u003c/i\u003e for this reaction?",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "HCl\u003ci\u003e(aq)\u003c/i\u003e + NaHCO\u003csub\u003e3\u003c/sub\u003e\u003ci\u003e(aq)\u003c/i\u003e \u0026rarr; NaCl\u003ci\u003e(aq)\u003c/i\u003e + H\u003csub\u003e2\u003c/sub\u003eO\u003ci\u003e(l)\u003c/i\u003e + CO\u003csub\u003e2\u003c/sub\u003e\u003ci\u003e(g)\u003c/i\u003e",
+                                                               "H\u003csup\u003e+\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e + HCO\u003csub\u003e3\u003c/sub\u003e\u003csup\u003e-\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e \u0026rarr; CO\u003csub\u003e2\u003c/sub\u003e\u003ci\u003e(g)\u003c/i\u003e +  H\u003csub\u003e2\u003c/sub\u003eO\u003ci\u003e(l)\u003c/i\u003e",
+                                                               "H\u003csup\u003e+\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e + Cl\u003csup\u003e-\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e + Na\u003csup\u003e+\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e + HCO\u003csub\u003e3\u003c/sub\u003e\u003csup\u003e-\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e \u0026rarr; Na\u003csup\u003e+\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e + Cl\u003csup\u003e-\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e + CO\u003csub\u003e2\u003c/sub\u003e\u003ci\u003e(g)\u003c/i\u003e +  H\u003csub\u003e2\u003c/sub\u003eO\u003ci\u003e(l)\u003c/i\u003e"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6328116800126976,
+                         "orderBy":  " 4.1b",
+                         "title":  "Balancing Chemical Equations",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93029,
+                                               "type":  "NUMERIC",
+                                               "text":  "Determine the missing coefficient (x) required to balance the equation:\u003cbr\u003e\r\nCH\u003csub\u003e4\u003c/sub\u003e + x O\u003csub\u003e2\u003c/sub\u003e \u0026rarr; CO\u003csub\u003e2\u003c/sub\u003e + 2 H\u003csub\u003e2\u003c/sub\u003eO",
+                                               "correctAnswer":  "2",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  95013,
+                                               "type":  "NUMERIC",
+                                               "text":  "Octane (C\u003csub\u003e8\u003c/sub\u003eH\u003csub\u003e18\u003c/sub\u003e) is an important component of gasoline.  How many moles of carbon dioxide are emitted into the atmosphere for each mole of octane burned in an automobile? ",
+                                               "correctAnswer":  "8",
+                                               "choices":  "",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "tag":  "moles",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  109022,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Select all of the following chemical reactions that are properly balanced.",
+                                               "correctAnswer":  "ade",
+                                               "choices":  [
+                                                               "CH\u003csub\u003e4\u003c/sub\u003e + 2 O\u003csub\u003e2\u003c/sub\u003e \u0026rarr; CO\u003csub\u003e2\u003c/sub\u003e + 2 H\u003csub\u003e2\u003c/sub\u003eO",
+                                                               "HCl + K\u003csub\u003e2\u003c/sub\u003eS \u0026rarr; H\u003csub\u003e2\u003c/sub\u003eS + 2 KCl",
+                                                               "H\u003csub\u003e2\u003c/sub\u003e + O\u003csub\u003e2\u003c/sub\u003e \u0026rarr; H\u003csub\u003e2\u003c/sub\u003eO",
+                                                               "4 Fe + 3 O\u003csub\u003e2\u003c/sub\u003e \u0026rarr; 2 Fe\u003csub\u003e2\u003c/sub\u003eO\u003csub\u003e3\u003c/sub\u003e",
+                                                               "NaHCO\u003csub\u003e3\u003c/sub\u003e + HCl  \u0026rarr; CO\u003csub\u003e2\u003c/sub\u003e + H\u003csub\u003e2\u003c/sub\u003eO + NaCl"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6298229951430656,
+                         "orderBy":  " 4.2",
+                         "title":  "Classifying Chemical Equations",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  105039,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "When sodium metal reacts with an aqueous solution of hydrochloric acid, which of the following gases is produced?",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "hydrogen",
+                                                               "oxygen",
+                                                               "chlorine",
+                                                               "carbon dioxide",
+                                                               "carbon monoxide"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  106018,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which of the following fuels react with oxygen to produce carbon dioxide, the most important greenhouse gas associated with global warming?",
+                                               "correctAnswer":  "abce",
+                                               "choices":  [
+                                                               "natural gas",
+                                                               "gasoline",
+                                                               "coal",
+                                                               "hydrogen",
+                                                               "diesel fuel"
+                                                           ],
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  107018,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "All hydroxides and oxides are insoluble \u003cb\u003eexcept\u003c/b\u003e ",
+                                               "correctAnswer":  "abe",
+                                               "choices":  [
+                                                               "group I elements",
+                                                               "NH\u003csub\u003e4\u003c/sub\u003e\u003csup\u003e+\u003c/sup\u003e",
+                                                               "NO\u003csub\u003e3\u003c/sub\u003e\u003csup\u003e-\u003c/sup\u003e",
+                                                               "all halide anions (i.e. Cl\u003csup\u003e-\u003c/sup\u003e)",
+                                                               "Ba\u003csup\u003e2+\u003c/sup\u003e"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4809491945619456,
+                         "orderBy":  " 4.3",
+                         "title":  "Reaction Stoichiometry",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93011,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "If a reaction vessel is charged with 1.5 mol of iron(III)oxide and 5 mol of carbon monoxide, which of the following is the limiting reagent of the reaction?\u003cbr\u003e\r\nFe\u003csub\u003e2\u003c/sub\u003eO\u003csub\u003e3\u003c/sub\u003e(s) + 3 CO(g) \u0026rarr; 2 Fe(s) + 3 CO\u003csub\u003e2\u003c/sub\u003e(g)",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "CO\u003csub\u003e2\u003c/sub\u003e(g)",
+                                                               "Fe(s)",
+                                                               "CO(g)",
+                                                               "Fe\u003csub\u003e2\u003c/sub\u003eO\u003csub\u003e3\u003c/sub\u003e(s)"
+                                                           ],
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  1554009,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "If a reaction vessel is charged with 1.5 mol of iron(III)oxide and 5 mol of carbon monoxide, which of the following is the limiting reagent of the reaction?\u003cbr\u003e\r\nFe\u003csub\u003e2\u003c/sub\u003eO\u003csub\u003e3\u003c/sub\u003e(s) + 3 CO(g) \u0026rarr; 2 Fe(s) + 3 CO\u003csub\u003e2\u003c/sub\u003e(g)",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "CO\u003csub\u003e2\u003c/sub\u003e(g)",
+                                                               "Fe(s)",
+                                                               "CO(g)",
+                                                               "Fe\u003csub\u003e2\u003c/sub\u003eO\u003csub\u003e3\u003c/sub\u003e(s)"
+                                                           ],
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6199006660657152,
+                                               "type":  "NUMERIC",
+                                               "text":  "Ammonia (NH\u003csub\u003e3\u003c/sub\u003e) is synthesized from nitrogen (N\u003csub\u003e2\u003c/sub\u003e) and hydrogen (H\u003csub\u003e2\u003c/sub\u003e) by mixing the reactants in the presence of a metal catalyst at high temperature and high pressure. How many moles of H\u003csub\u003e2\u003c/sub\u003e are required to make #a/10# moles of ammonia?",
+                                               "correctAnswer":  "a/10*3/2",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  3,
+                                               "tag":  "mol H\u003csub\u003e2\u003c/sub\u003e",
+                                               "parameterString":  "a 110:350",
+                                               "solution":  "The balanced reaction is:\u003cbr/\u003e\r\nN\u003csub\u003e2\u003c/sub\u003e + 3 H\u003csub\u003e2\u003c/sub\u003e \u0026rarr; 2 NH\u003csub\u003e3\u003c/sub\u003e\u003cbr/\u003e\r\n3 mol H\u003csub\u003e2\u003c/sub\u003e = 2 mol NH\u003csub\u003e3\u003c/sub\u003e\u003cbr/\u003e\r\nmoles H\u003csub\u003e2\u003c/sub\u003e needed = #a/10# mol NH\u003csub\u003e3\u003c/sub\u003e * (|3 mol H2|2 mol NH3|) = #a/10*3/2# mol H\u003csub\u003e2\u003c/sub\u003e",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  5957383678853120,
+                         "orderBy":  " 4.4",
+                         "title":  "Reaction Yields",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  112039,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "If a reaction vessel is charged with 5 mol of lithium reacts and 2 mol of barium chloride, which of the following is the limiting reagent of the reaction?\u003cbr\u003e\r\n\r\nBaCl\u003csub\u003e2\u003c/sub\u003e(s) + 2 Li(s) \u0026rarr; Ba(s) + 2 LiCl(s)",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "BaCl\u003csub\u003e2\u003c/sub\u003e(s)",
+                                                               "Li(s)",
+                                                               "LiCl(s)",
+                                                               "Ba(s)"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  184003,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "If a reaction vessel is charged with 3 mol of chlorine gas reacts and 4 mol of sodium azide, which of the following is the limiting reagent of the reaction?\u003cbr\u003e\r\nCl\u003csub\u003e2\u003c/sub\u003e(g) + NaN\u003csub\u003e3\u003c/sub\u003e(s) \u0026rarr; ClN\u003csub\u003e3\u003c/sub\u003e(g) + NaCl(s)",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "NaCl(s)",
+                                                               "Cl\u003csub\u003e2\u003c/sub\u003e(g)",
+                                                               "NaN\u003csub\u003e3\u003c/sub\u003e(s)",
+                                                               "ClN\u003csub\u003e3\u003c/sub\u003e(g) "
+                                                           ],
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  1553010,
+                                               "type":  "NUMERIC",
+                                               "text":  "What mass of phosphorus will react with Cl\u003csub\u003e2\u003c/sub\u003e to make #a/10# mol of PCl\u003csub\u003e5\u003c/sub\u003e?",
+                                               "correctAnswer":  "a/10*30.97",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  3,
+                                               "tag":  "g",
+                                               "parameterString":  "a 40:99",
+                                               "solution":  "The balanced reaction is \u003cbr\u003e\r\nP + 5/2 Cl\u003csub\u003e2\u003c/sub\u003e \u0026rarr; PCl\u003csub\u003e5\u003c/sub\u003e\u003cbr\u003e\r\n\r\n#a/10# mol of P is required to make #a/10# mol of PCl\u003csub\u003e5\u003c/sub\u003e, and the mass of reactant is\u003cbr\u003e\r\n#a/10# mol * 30.97 g/mol = #a/10*30.97# g",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6194249464283136,
+                         "orderBy":  " 4.5",
+                         "title":  "Quantitative Analysis",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  4791675041087488,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "A solution that has a pH of less than 7 is considered ________.",
+                                               "correctAnswer":  "acidic",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6199266741059584,
+                                               "type":  "NUMERIC",
+                                               "text":  "A solution containing #a/1000# moles of hydrochloric acid was titrated with a solution of sodium hydroxide to the endpoint, which occurred at #b/10# mL added base.\u003cbr/\u003e\r\nNaOH(aq) + HCl(aq) \u0026rarr; NaCl(aq) + H\u003csub\u003e2\u003c/sub\u003eO(l)\u003cbr/\u003e\r\nWhat was the concentration of the original NaOH solution?",
+                                               "correctAnswer":  "a/1000/(b/10)/1e-3",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  3,
+                                               "tag":  "M NaOH",
+                                               "parameterString":  "a 13:25 b 600:950",
+                                               "solution":  "Starting point: (|#a/1000# mol HCl|#b/10# mL soln|)\u003cbr/\u003e\r\nGoal: (|mol NaOH|1 L soln|)\u003cbr/\u003e\r\n(|#a/1000# mol HCl|#b/10# mL NaOH|) * (|1 mL|10\u003csup\u003e-3\u003c/sup\u003e L|) * (|1 mol NaOH|1 mol HCl|) = #a/1000/(b/10)/1e-3# (|mol NaOH|1 L soln|) = #a/1000/(b/10)/1e-3#  M NaOH\r\n",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false,
+                                               "hints":  "The concentration of the original NaOH solution is equal to the number moles of acid neutralized divided by the volume of solution added in the titration."
+                                           },
+                                           {
+                                               "id":  6216448355074048,
+                                               "type":  "NUMERIC",
+                                               "text":  "When #a/100# g of silver nitrate is added to a solution containing excess NaCl(\u003ci\u003eaq\u003c/i\u003e), a precipitate of AgCl(s) is collected, washed and dried. The mass of the precipitate is #a/100*143.32/169.87*b/1000# g. What is the percent yield for the reaction?",
+                                               "correctAnswer":  "b/1000*100",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  3,
+                                               "tag":  "% yield",
+                                               "parameterString":  "a 302:880 b 851:950",
+                                               "solution":  "Theoretical yield:\u003cbr/\u003e\r\n#a/100# g AgNO3 * (|1 mol AgNO3|169.87 g AgNO3|) * (|1 mol AgCl|1 mol AgNO3|) * (|143.32 g AgCl|1 mol AgCl|) = #a/100/169.87*143.32# g AgCl\u003cbr/\u003e\r\nPercent yield = (|observed yield|theoretical yield|) * 100% = (|#a/100*143.32/169.87*b/1000# g AgCl|#a/100/169.87*143.32# g AgCl|) * 100% = #b/1000*100#% yield\u003cbr/\u003e",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false,
+                                               "hints":  [
+                                                             "The balanced net ionic equation is",
+                                                             "Ag\u003csup\u003e+\u003c/sup\u003e(\u003ci\u003eaq\u003c/i\u003e) + Cl\u003csup\u003e-\u003c/sup\u003e(\u003ci\u003eaq\u003c/i\u003e) \u0026rarr; AgCl(\u003ci\u003es\u003c/i\u003e)"
+                                                         ]
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6329296909500416,
+                         "orderBy":  " 5.1",
+                         "title":  "Heat and Work",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  96015,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "A process that occurs at constant pressure is said to be a(n)",
+                                               "correctAnswer":  "isobaric",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " process.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  106011,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The following are examples of thermochemical work",
+                                               "correctAnswer":  "abcd",
+                                               "choices":  [
+                                                               "mechanical force acting over a distance",
+                                                               "expansion against an opposing pressure",
+                                                               "charge moving through a potential difference",
+                                                               "elongation of elastic material acting against a tension",
+                                                               "free rotation about a point in space"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  109029,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The energy in a system that is representative of its ability to do work is referred to as ",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "kinetic energy.",
+                                                               "potential energy.",
+                                                               "thermal energy.",
+                                                               "ionization energy.",
+                                                               "electrical energy."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6253708907642880,
+                         "orderBy":  " 5.2",
+                         "title":  "Calorimetry",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  186008,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Which has the higher value of \u003ci\u003emolar\u003c/i\u003e heat capacity at constant pressure?",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "Fe\u003ci\u003e(s)\u003c/i\u003e",
+                                                               "H\u003csub\u003e2\u003c/sub\u003eO\u003ci\u003e(l)\u003c/i\u003e",
+                                                               "",
+                                                               "",
+                                                               ""
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  189028,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The measure of the rise in temperature when a substance absorbs heat is called its",
+                                               "correctAnswer":  "specific heat capacity, specific heat, heat capacity",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  941520,
+                                               "type":  "NUMERIC",
+                                               "text":  "If the specific heat capacity of a metal is #a*10# J/(kg-K), what is the predicted change in temperature when #b# J of heat is added to a #c/100# kg sample of the metal?",
+                                               "correctAnswer":  "b/(c/100)/(a*10)",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  3,
+                                               "tag":  "K",
+                                               "parameterString":  "a 10:70 b 15:85 c 25:75",
+                                               "solution":  "The predicted temperature rise is directly proportional to the amount of heat added and inversely proportional to the sample mass and specific heat capacity:\u003cbr\u003e\r\n\u0026Delta;T = (#b# J) / (#c/100# kg) / (#a*10# J/(kg-K)) = #b/(c/100)/(a*10)# K",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6303550879039488,
+                         "orderBy":  " 5.3a",
+                         "title":  "Enthalpy",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  106020,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The thermodynamic standard state of a solid is defined to include the following",
+                                               "correctAnswer":  "abd",
+                                               "choices":  [
+                                                               "1 bar pressure",
+                                                               "pure thermodynamically stable state",
+                                                               "ideal behavior",
+                                                               "specified temperature of interest",
+                                                               "1 M concentration"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  109028,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "For an ideal gas, the relationship between molar heat capacities is",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "c\u003csub\u003eP\u003c/sub\u003e = c\u003csub\u003eV\u003c/sub\u003e + 0.5 R",
+                                                               "c\u003csub\u003eP\u003c/sub\u003e = c\u003csub\u003eV\u003c/sub\u003e + 1.0 R",
+                                                               "c\u003csub\u003eP\u003c/sub\u003e = c\u003csub\u003eV\u003c/sub\u003e + 1.5 R",
+                                                               "c\u003csub\u003eP\u003c/sub\u003e = c\u003csub\u003eV\u003c/sub\u003e + 2.0 R",
+                                                               "c\u003csub\u003eP\u003c/sub\u003e = c\u003csub\u003eV\u003c/sub\u003e + 2.5 R"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  145040,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "An important property of thermodynamic state functions is that their values depend only on the state of a system and not on the thermodynamic",
+                                               "correctAnswer":  "pathway,pathways,path,paths",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  " followed to reach it.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6330502251806720,
+                         "orderBy":  " 5.3b",
+                         "title":  "First Law of Thermodynamics",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  124016,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "A thermodynamic system that is confined by physical barriers and not allowed to exchange matter with the surroundings is said to be",
+                                               "correctAnswer":  "closed",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  148017,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "A thermodynamic system in which matter is exchanged freely with the surroundings with no physical barriers is said to be",
+                                               "correctAnswer":  "open",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  197004,
+                                               "type":  "NUMERIC",
+                                               "text":  "If the following reaction is carried out at constant volume:\u003cbr\u003e 2 Na(s) + Cl\u003csub\u003e2\u003c/sub\u003e(g) \u0026rarr; 2NaCl(s)\u003cbr\u003e\r\nCalculate the work done on the system. \u0026Delta;H\u003csub\u003ef\u003c/sub\u003e\u003csup\u003eo\u003c/sup\u003e NaCl(g)=-181.42 kJ/mol",
+                                               "correctAnswer":  "0",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  "kJ/mol",
+                                               "solution":  "No work is done in isochoric experiments, because \u0026Delta;V is zero.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4908674350317568,
+                         "orderBy":  " 5.3c",
+                         "title":  "Enthalpy of Reaction",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  5705038505705472,
+                                               "type":  "TRUE_FALSE",
+                                               "text":  "The change in enthalpy for an exothermic reaction is always less than zero.",
+                                               "correctAnswer":  "true",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5705731354918912,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "If an open beaker containing a reacting mixture becomes warm to the touch, which statement is true?",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "the reaction is endothermic and \u0026Delta;H\u003e0.",
+                                                               "the reaction is endothermic and \u0026Delta;H\u003c0.",
+                                                               "the reaction is exothermic and \u0026Delta;H\u003e0.",
+                                                               "the reaction is exothermic and \u0026Delta;H\u003c0."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5738759166361600,
+                                               "type":  "TRUE_FALSE",
+                                               "text":  "The enthalpy change for a reaction is independent of the physical state (e.g., liquid or gas) of the reactants and products.",
+                                               "correctAnswer":  "false",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6227766365650944,
+                         "orderBy":  " 5.3d",
+                         "title":  "Hess\u0027 Law",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  4880782928904192,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Hess\u0027 Law states that enthalpy is a _________ function, meaning its change is independent of the path taken.",
+                                               "correctAnswer":  "state",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6217265268916224,
+                                               "type":  "NUMERIC",
+                                               "text":  "If a reaction having \u0026Delta;H=#a# kJ/mol is reversed, what is the value of \u0026Delta;H for the reversed reaction?",
+                                               "correctAnswer":  "-a",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "kJ/mol",
+                                               "parameterString":  "a -299:299",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6244110628814848,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Hess\u0027s Law states that",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "the enthalpy change of a multi-step process is equal to the sum of the enthalpy changes of the steps.",
+                                                               "the enthalpy change of a process is equal to the difference between the enthalpies of the reactants and products.",
+                                                               "the enthalpy change of a reversible process is always equal to zero.",
+                                                               "the enthalpy change of an exothermic process is always greater than zero.",
+                                                               "the enthalpy change of a spontaneous process is always less than zero."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6227956820606976,
+                         "orderBy":  " 6.1a",
+                         "title":  "Wave Nature of Light",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  92022,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which electromagnetic waves have a shorter wavelength than visible light?",
+                                               "correctAnswer":  "ace",
+                                               "choices":  [
+                                                               "gamma rays",
+                                                               "infrared radiation",
+                                                               "ultraviolet waves",
+                                                               "microwaves",
+                                                               "X-rays"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  102017,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The point in a standing wave where the amplitude of oscillation is zero is called a",
+                                               "correctAnswer":  "node",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  125017,
+                                               "type":  "NUMERIC",
+                                               "text":  "The speed of electromagnetic waves in vacuum is",
+                                               "correctAnswer":  "2.998E+08",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  "m/s",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6211879097073664,
+                         "orderBy":  " 6.1b",
+                         "title":  "Blackbody Radiation",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  140020,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The two most influential experimental observations that led to the development of quantum mechanics were the photoelectric effect and",
+                                               "correctAnswer":  "blackbody radiation,black-body radiation",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " .",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  144029,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Rayleigh and Jeans used classical mechanics to predict the wavelength distribution of blackbody radiation. The prediction",
+                                               "correctAnswer":  "c",
+                                               "choices":  [
+                                                               "agreed well with experimental observations at all wavelengths.",
+                                                               "agreed with experiments at long wavelengths but underpredicted the intensity at short wavelengths.",
+                                                               "agreed with experiments at long wavelengths but overpredicted the intensity at short wavelengths.",
+                                                               "agreed with experiments at short wavelengths but underpredicted the intensity at long wavelengths.",
+                                                               "agreed with experiments at short wavelengths but overpredicted the intensity at long wavelengths."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  154027,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The distribution of intensities of blackbody radiation shifts to ",
+                                               "correctAnswer":  "shorter,smaller",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " wavelengths as the temperature is increased.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6201507019489280,
+                         "orderBy":  " 6.1c",
+                         "title":  "Photoelectric Effect",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  127033,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "In the photoelectric effect, the difference in energy between the incident photons and the kinetic energy of the emitted electrons is called the",
+                                               "correctAnswer":  "work function,binding energy,ionization energy",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " of the metal.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  145021,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The photoelectric effect shows that the photocurrent of ejected electrons is proportional to",
+                                               "correctAnswer":  "c",
+                                               "choices":  [
+                                                               "the intensity of the incident light, but only below a characteristic threshold frequency.",
+                                                               "the frequency of the incident light, but only below a characteristic threshold intensity.",
+                                                               "the intensity of the incident light, but only above a characteristic threshold frequency.",
+                                                               "the frequency of the incident light, but only above a characteristic threshold intensity.",
+                                                               "both the frequency and intensity of the incident light."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  155017,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "One of the discoveries that led to the development of quantum mechanics was the observation of the",
+                                               "correctAnswer":  "photoelectric",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "effect, where metals emit electrons when light shines on the surface.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6305969130176512,
+                         "orderBy":  " 6.1d",
+                         "title":  "Line Spectra",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  127031,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The emission spectrum of hydrogen and other atoms is not continuous, but consists of bright lines at discrete",
+                                               "correctAnswer":  "wavelengths,frequencies",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "that are characteristic of each atom.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  143028,
+                                               "type":  "NUMERIC",
+                                               "text":  "For the hydrogen atom, the set of spectral lines described by the Lyman series all have a common final state corresponding to n = ",
+                                               "correctAnswer":  "1",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  143029,
+                                               "type":  "NUMERIC",
+                                               "text":  "For the hydrogen atom, the set of spectral lines described by the Balmer series all have a common final state corresponding to n = ",
+                                               "correctAnswer":  "2",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6247410019336192,
+                         "orderBy":  " 6.2",
+                         "title":  "Bohr Model \u0026 Rydberg Equation",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  102013,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "An early model of the hydrogen atom was proposed by the Danish physicist",
+                                               "correctAnswer":  "Niels Bohr,Bohr",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "in which electrons traveled in circular orbits only at certain specific distances from the nucleus of the atom.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  180031,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Niels Bohr proposed a model of the hydrogen atom in which each line in the emission spectrum corresponds to a",
+                                               "correctAnswer":  "transition",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " between two states of the atom.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5865339,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "We say that the energy of an atom is",
+                                               "correctAnswer":  "quantized",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "because the energy can only take on certain discrete values.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6217793803911168,
+                         "orderBy":  " 6.3a",
+                         "title":  "Wave-Particle Duality",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  98011,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The wave-particle duality of electrons is summarized by the de Broglie relation, which states that the characteristic wavelength is inversely proportional to the",
+                                               "correctAnswer":  "momentum",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "of the particle.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  98012,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Louis de Broglie won the Nobel Prize in 1929 for his discovery that the characteristic wavelength of an electron is inversely proportional to its linear",
+                                               "correctAnswer":  "momentum",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ", where the constant of proportionality is Planck\u0027s constant.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  127032,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "According to quantum mechanics, all particles of matter exhibit some of the properties normally associated with",
+                                               "correctAnswer":  "waves",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6269772169216000,
+                         "orderBy":  " 6.3b",
+                         "title":  "Heisenberg Uncertainty Princiiple",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  107030,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The Heisenberg Uncertainty Principle states for any particle, it is impossible to simultaneously determine the exact position and the exact",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "mass",
+                                                               "energy",
+                                                               "volume",
+                                                               "momentum",
+                                                               "quantum number"
+                                                           ],
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  150024,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Heisenberg\u0027s uncertainty principle sets an absolute lower bound on the product of uncertainties for the momentum and",
+                                               "correctAnswer":  "position,location",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " of any particle.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5826367,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Heisenberg\u0027s uncertainty principle sets an absolute lower bound on the product of uncertainties for the momentum and",
+                                               "correctAnswer":  "position,location",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  " of any particle.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6320951184064512,
+                         "orderBy":  " 6.3c",
+                         "title":  "Atomic Orbitals \u0026 Energy",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  94014,
+                                               "type":  "NUMERIC",
+                                               "text":  "Each hydrogen atom has",
+                                               "correctAnswer":  "5",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "different 3d orbitals, each having exactly the same energy.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  94015,
+                                               "type":  "NUMERIC",
+                                               "text":  "Each hydrogen atom has",
+                                               "correctAnswer":  "5",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "different 4d orbitals, each having exactly the same energy.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  112025,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "In many-electron atoms, the 2p orbital is higher in energy than the 2s because",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "the 2p electron has better penetration of the region nearest the nucleus",
+                                                               "the 2s electron has better penetration of the region nearest the nucleus",
+                                                               "the greater angular momentum of the 2p orbital directly lowers its energy",
+                                                               "the 2s electron is shielded from the nuclear charge, lowering its energy",
+                                                               "the 2p electron is shielded from the nuclear charge, lowering its energy"
+                                                           ],
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6319232928710656,
+                         "orderBy":  " 6.3d",
+                         "title":  "Pauli Exclusion Principle",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  178010,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which two statements properly describe the Pauli Exclusion Principle?",
+                                               "correctAnswer":  "ce",
+                                               "choices":  [
+                                                               "when two or more electrons occupy the same space, they repel each other",
+                                                               "the probability density of finding an electron is proportional to the square of its wave function",
+                                                               "no orbital can be occupied by more than 2 electrons",
+                                                               "the orbitals within a principal level of a multielectron atom are degenerate",
+                                                               "no two electrons can have exactly the same set of quantum numbers"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5944362,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The limitation that no two electrons in an atom can have exactly the same set of quantum numbers is called the Pauli",
+                                               "correctAnswer":  "Exclusion",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  "Principle.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5953374,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "When two electrons occupy the same atomic orbital, ",
+                                               "correctAnswer":  "c",
+                                               "choices":  [
+                                                               "both electrons must be spin up.",
+                                                               "both electrons must be spin down.",
+                                                               "one electron must be spin up and the other spin down.",
+                                                               "the electrons can take on any spin quantum numbers."
+                                                           ],
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6079877488312320,
+                         "orderBy":  " 6.4a",
+                         "title":  "Aufbau Principle",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  4865518334377984,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Electron configurations of atoms can be determined using the",
+                                               "correctAnswer":  "Aufbau,building up",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "principle, in which each added electron occupies the lowest energy available subshell.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4869484065587200,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "After completely filling the 3d subshell of an atom, the next higher energy subshell is",
+                                               "correctAnswer":  "4p",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6034376382218240,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The name \u0027Aufbau\u0027 is derived from a _______ word that means \u0027building up\u0027 or \u0027construction.\u0027",
+                                               "correctAnswer":  "German",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6267145729605632,
+                         "orderBy":  " 6.4b",
+                         "title":  "Electron configurations",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  127034,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Which neutral atom has the valence electron configuration 5s\u003csup\u003e2\u003c/sup\u003e4d\u003csup\u003e10\u003c/sup\u003e5p\u003csup\u003e6\u003c/sup\u003e?",
+                                               "correctAnswer":  "Xe,xenon",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  154022,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Which neutral atom has the valence electron configuration 4s\u003csup\u003e2\u003c/sup\u003e3d\u003csup\u003e10\u003c/sup\u003e4p\u003csup\u003e4\u003c/sup\u003e?",
+                                               "correctAnswer":  "Se,selenium",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  177012,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Which neutral atom has the valence electron configuration 3s\u003csup\u003e2\u003c/sup\u003e3p\u003csup\u003e1\u003c/sup\u003e?",
+                                               "correctAnswer":  "Al,aluminum,aluminium",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6283215483961344,
+                         "orderBy":  " 6.5",
+                         "title":  "Periodic Trends: Size, IE, EA",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  97011,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Within each row of the Periodic Table of Elements, the atom with the smallest atomic radius is the one having the",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "smallest atomic number.",
+                                                               "largest atomic number."
+                                                           ],
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  97012,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Within each row of the Periodic Table of Elements, the atom with the largest atomic radius is the one in the",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "first column.",
+                                                               "last column.",
+                                                               "middle column."
+                                                           ],
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  122016,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Within each column of the Periodic Table of Elements, the atom with the largest atomic radius is the one with the",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "highest atomic number.",
+                                                               "lowest atomic number."
+                                                           ],
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4831919442755584,
+                         "orderBy":  " 7.1",
+                         "title":  "Ionic Bonding",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  159020,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Which type of chemical bonding holds the atoms together in a crystal of potassium iodide?",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "ionic bonding",
+                                                               "covalent bonding",
+                                                               "metallic bonding",
+                                                               "hydrogen bonding",
+                                                               "van der Waals bonding"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  159021,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Which type of chemical bonding holds the atoms together in quicklime (calcium oxide)?",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "ionic bonding",
+                                                               "covalent bonding",
+                                                               "metallic bonding",
+                                                               "hydrogen bonding",
+                                                               "van der Waals bonding"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6193480627126272,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Ionic compounds generally have ________ melting and boiling points due to the strong electrostatic forces of attraction.",
+                                               "correctAnswer":  "high",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4820581937053696,
+                         "orderBy":  " 7.2",
+                         "title":  "Covalent Bonding",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  105031,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "As a general rule, if the electronegativity difference between two atoms is smaller than 0.4, the bond formed between them is said to be a(n)",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "covalent bond",
+                                                               "coordinate covalent bond",
+                                                               "polar covalent bond",
+                                                               "hydrogen bond",
+                                                               "ionic bond"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  111029,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Which type of chemical bonding holds the atoms together in liquid xenon?",
+                                               "correctAnswer":  "e",
+                                               "choices":  [
+                                                               "ionic bonding",
+                                                               "covalent bonding",
+                                                               "metallic bonding",
+                                                               "hydrogen bonding",
+                                                               "van der Waals bonding"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  111030,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "As a general rule, if the electronegativity difference between two atoms has a value greater than 2.0, the bond formed between them is said to be a(n)",
+                                               "correctAnswer":  "e",
+                                               "choices":  [
+                                                               "covalent bond",
+                                                               "coordinate covalent bond",
+                                                               "polar covalent bond",
+                                                               "hydrogen bond",
+                                                               "ionic bond"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  5516927534891008,
+                         "orderBy":  " 7.3",
+                         "title":  "Lewis Structures",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  95011,
+                                               "type":  "NUMERIC",
+                                               "text":  "Draw the Lewis structure for the Lewis acid/base complex BF\u003csub\u003e3\u003c/sub\u003eNH\u003csub\u003e3\u003c/sub\u003e. How many valence electrons surround the N atom in this structure?",
+                                               "correctAnswer":  "8",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "electrons",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  95012,
+                                               "type":  "NUMERIC",
+                                               "text":  "Draw the Lewis structure for the Lewis acid/base complex BF\u003csub\u003e3\u003c/sub\u003eNH\u003csub\u003e3\u003c/sub\u003e. How many valence electrons surround the B atom in this structure?",
+                                               "correctAnswer":  "8",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "electrons",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  95015,
+                                               "type":  "NUMERIC",
+                                               "text":  "Draw the Lewis structure for phosphoric acid (H\u003csub\u003e3\u003c/sub\u003ePO\u003csub\u003e4\u003c/sub\u003e). How many valence electrons surround the central P atom in this structure?",
+                                               "correctAnswer":  "10",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "electrons",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6279323236958208,
+                         "orderBy":  " 7.4",
+                         "title":  "Formal Charges and Resonance",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93022,
+                                               "type":  "NUMERIC",
+                                               "text":  "In the Lewis resonance structure for chlorate ion (ClO\u003csub\u003e3\u003c/sub\u003e\u003csup\u003e-\u003c/sup\u003e) in which the central Cl atom is singly bonded to each of the three O atoms, what is the formal charge of the central Cl atom?",
+                                               "correctAnswer":  "2",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  180029,
+                                               "type":  "NUMERIC",
+                                               "text":  "In the Lewis resonance structure for nitrous oxide (NNO) in which the central N atom is doubly bonded to each of the other two atoms, what is the formal charge on the outer N atom?",
+                                               "correctAnswer":  "-1",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "solution":  "The outer N atom is surrounded by 8 electrons (4 electrons in the double bond, plus 2 lone pairs). Its formal charge is equal to 5 (the original number of valence electrons on N) minus 6 (2 lone pairs plus half the number of electrons in the double bond).  Formal charge = 5-6 = -1.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  196002,
+                                               "type":  "NUMERIC",
+                                               "text":  "In the Lewis resonance structure for carbon dioxide (CO\u003csub\u003e2\u003c/sub\u003e) in which the central C atom is doubly bonded to each of the two O atoms, what is the formal charge on the central C atom?",
+                                               "correctAnswer":  "0",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4837946103955456,
+                         "orderBy":  " 7.5",
+                         "title":  "Strengths of Chemical Bonds",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  154013,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Which of the following \u003ci\u003esingle\u003c/i\u003e bonds has the lowest bond dissociation energy (\u003ci\u003ei.e.\u003c/i\u003e, will break most easily)?",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "H-C",
+                                                               "N-C",
+                                                               "N-H",
+                                                               "O-O",
+                                                               "H-O"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6210739877707776,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Metals are malleable and conduct electricity through a \u0027sea of electrons\u0027 due to __________ bonds.",
+                                               "correctAnswer":  "metallic",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6215910209093632,
+                                               "type":  "NUMERIC",
+                                               "text":  "Estimate the change in enthalpy for synthesis of 1 mole of ammonia (NH\u003csub\u003e3\u003c/sub\u003e) from N\u003csub\u003e2\u003c/sub\u003e and H\u003csub\u003e2\u003c/sub\u003e.\u003cbr/\u003e\r\nAverage bond energies are H-H (436 kJ/mol), N\u0026equiv;N (946 kJ/mol), and H-N (390 kJ/mol).",
+                                               "correctAnswer":  "-43",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  "kJ/mol",
+                                               "solution":  "For every 2 moles of NH\u003csub\u003e3\u003c/sub\u003e formed, we must break 3 H-H bonds and 1 N\u0026equiv;N bond, but we also form 6 H-N bonds:\u003cbr/\u003e\r\nChange in enthalpy = 3*436 + 946 - 6*390 = -86 kJ/mol\u003cbr/\u003e\r\nThen for every 1 mol of NH\u003csub\u003e3\u003c/sub\u003e formed, \u0026Delta;H = -86/2 = -43 kJ/mol",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false,
+                                               "hints":  [
+                                                             "The balanced reaction is",
+                                                             "3 H\u003csub\u003e2\u003c/sub\u003e + N\u003csub\u003e2\u003c/sub\u003e \u0026rarr; 2 NH\u003csub\u003e3\u003c/sub\u003e"
+                                                         ]
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6284451696345088,
+                         "orderBy":  " 7.6",
+                         "title":  "Molecular Structure \u0026 Polarity",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  94016,
+                                               "type":  "NUMERIC",
+                                               "text":  "According to VSEPR theory, the number of valence electron groups surrounding the central atom in SF\u003csub\u003e4\u003c/sub\u003e is",
+                                               "correctAnswer":  "5",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  105035,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "If a central atom has 2 equivalent bonds to other atoms and no extra lone pairs of electrons, then the shape of the molecule is said to be",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "linear",
+                                                               "trigonal planar",
+                                                               "tetrahedral",
+                                                               "trigonal bipyramidal",
+                                                               "octahedral"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  106017,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which of the following molecules has a net dipole moment?",
+                                               "correctAnswer":  "abce",
+                                               "choices":  [
+                                                               "HCl (linear)",
+                                                               "NH\u003csub\u003e3\u003c/sub\u003e (trigonal pryamidal)",
+                                                               "CH\u003csub\u003e3\u003c/sub\u003eCl (approx. tetrahedral)",
+                                                               "SF\u003csub\u003e6\u003c/sub\u003e (octahedral)",
+                                                               "SF\u003csub\u003e4\u003c/sub\u003e (see saw)"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6316934668222464,
+                         "orderBy":  " 8.1",
+                         "title":  "Valence Bond Theory",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  94019,
+                                               "type":  "NUMERIC",
+                                               "text":  "According to VSEPR theory, the number of valence electron groups surrounding the central atom in ICl\u003csub\u003e3\u003c/sub\u003e is",
+                                               "correctAnswer":  "5",
+                                               "choices":  "",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  94020,
+                                               "type":  "NUMERIC",
+                                               "text":  "According to VSEPR theory, the number of valence electron groups surrounding the central atom in SF\u003csub\u003e4\u003c/sub\u003e is",
+                                               "correctAnswer":  "5",
+                                               "choices":  "",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  105040,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Valence shell electron pair repulsion (VSEPR) theory predicts that if the central atom in a molecule has 6 electron groups (bonds or lone pairs), the bond angles around the central atom will be approximately",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "90 degrees",
+                                                               "109.5 degrees",
+                                                               "120 degrees",
+                                                               "90 and 120 degrees",
+                                                               "180 degrees"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6322340018782208,
+                         "orderBy":  " 8.2",
+                         "title":  "Hybrid Atomic Orbitals",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93023,
+                                               "type":  "NUMERIC",
+                                               "text":  "According to valence bond (VB) theory, the carbon atom in formaldehyde (H\u003csub\u003e2\u003c/sub\u003eCO) forms sp\u003csup\u003e\u003ci\u003ex\u003c/i\u003e\u003c/sup\u003e hybrid orbitals in order to bond to the surrounding oxygen and two hydrogen atoms.  What is the value of \u003ci\u003ex\u003c/i\u003e?",
+                                               "correctAnswer":  "2",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  112037,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Two valence bond orbitals formed from linear combinations of one s orbital and one p orbital are called",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "\u003ci\u003esp\u003c/i\u003e hybrid molecular orbitals",
+                                                               "\u003ci\u003esp\u003csup\u003e2\u003c/sup\u003e\u003c/i\u003e hybrid molecular orbitals",
+                                                               "\u003ci\u003esp\u003csup\u003e3\u003c/sup\u003e\u003c/i\u003e hybrid molecular orbitals",
+                                                               "\u003ci\u003esp\u003csup\u003e4\u003c/sup\u003e\u003c/i\u003e hybrid molecular orbitals"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  129026,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "If a central atom has 5 equivalent bonds to other atoms and no extra lone pairs of electrons, then the shape of the molecule is said to be",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "linear",
+                                                               "trigonal planar",
+                                                               "tetrahedral",
+                                                               "trigonal bipyramidal",
+                                                               "octahedral"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6306159585132544,
+                         "orderBy":  " 8.3",
+                         "title":  "Multiple Bonds",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  123020,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "A molecule that has two or more double or triple bonds that alternate with single bonds is an example of a",
+                                               "correctAnswer":  "conjugated",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " pi electron system.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4825120607830016,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "A double bond between carbon atoms consists of one sigma bond and one _______ bond.",
+                                               "correctAnswer":  "pi",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6192707585441792,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Alkenes are hydrocarbons that contain at least one ______ bond between carbon atoms.",
+                                               "correctAnswer":  "double",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6250092696174592,
+                         "orderBy":  " 8.4",
+                         "title":  "Molecular Orbital Theory",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93025,
+                                               "type":  "NUMERIC",
+                                               "text":  "According to molecular orbital (MO) theory, the predicted bond order of O\u003csub\u003e2\u003c/sub\u003e is",
+                                               "correctAnswer":  "2",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  102019,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "When a molecular orbital has an energy that is \u003ci\u003ethe same as\u003c/i\u003e the orbitals from which it is formed, we call this a(n)",
+                                               "correctAnswer":  "nonbonding",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "orbital.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  105033,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The predicted bond order for the Be\u003csub\u003e2\u003c/sub\u003e diatomic molecule is",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "0",
+                                                               "1/2",
+                                                               "1",
+                                                               "3/2",
+                                                               "2"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6316544430178304,
+                         "orderBy":  " 9.1",
+                         "title":  "Gas Pressure",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  107013,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which three of the following are important greenhouse gases in the atmosphere?",
+                                               "correctAnswer":  "abd",
+                                               "choices":  [
+                                                               "methane",
+                                                               "water vapor",
+                                                               "carbon monoxide",
+                                                               "carbon dioxide",
+                                                               "nitrogen"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  107026,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Heating mercury (II) oxide, HgO, produces which product gas?",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "Hg",
+                                                               "HgO",
+                                                               "O",
+                                                               "O\u003csub\u003e2\u003c/sub\u003e",
+                                                               "Hg\u003csub\u003e2\u003c/sub\u003eO"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  107027,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The SI unit of pressure is ",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "atm",
+                                                               "mm Hg",
+                                                               "bar",
+                                                               "Pa",
+                                                               "psi"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6302572213698560,
+                         "orderBy":  " 9.2a",
+                         "title":  "Simple Gas Laws",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  112021,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Avogadro\u0027s Law states that the volume occupied by a gas, when held at constant temperature and pressure, is directly proportional to",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "the external pressure.",
+                                                               "the number of moles of gas in the container.",
+                                                               "its internal temperature.",
+                                                               "its volume.",
+                                                               "the value of the universal gas constant."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  126013,
+                                               "type":  "NUMERIC",
+                                               "text":  "If an ideal gas initially at #0.5*a# atm and #0.5*b*c# L is compressed at constant temperature to #0.5*b# L, what is the final pressure of the gas?",
+                                               "correctAnswer":  "0.5*a*c",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "tag":  "atm",
+                                               "parameterString":  "a 2:10 b 2:5 c 2:5",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  144027,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The equation\u003cbr\u003e\r\nV\u003csub\u003e1\u003c/sub\u003e / T\u003csub\u003e1\u003c/sub\u003e = V\u003csub\u003e2\u003c/sub\u003e / T\u003csub\u003e2\u003c/sub\u003e\u003cbr\u003e\r\nis a statement of",
+                                               "correctAnswer":  "c",
+                                               "choices":  [
+                                                               "Avogadro\u0027s Law",
+                                                               "Boyle\u0027s Law",
+                                                               "Charles\u0027 Law",
+                                                               "Dalton\u0027s Law",
+                                                               "ideal gas law"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6230876945383424,
+                         "orderBy":  " 9.2b",
+                         "title":  "Ideal Gas Law",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  111028,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The equation\u003cbr\u003e\r\nPV = nRT\u003cbr\u003e\r\nis a statement of",
+                                               "correctAnswer":  "e",
+                                               "choices":  [
+                                                               "Avogadro\u0027s Law",
+                                                               "Boyle\u0027s Law",
+                                                               "Charles\u0027 Law",
+                                                               "Dalton\u0027s Law",
+                                                               "ideal gas law"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  127036,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which two of the following are approximations are made by the ideal gas equation of state?",
+                                               "correctAnswer":  "ab",
+                                               "choices":  [
+                                                               "the volume occupied by the molecules is negligible",
+                                                               "the intermolecular forces between molecules are negligible",
+                                                               "the molar masses of the molecules are negligible",
+                                                               "molecules undergo collisions with the walls but not with each other",
+                                                               "molecular speeds are independent of temperature"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  176003,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The ideal gas law states that the pressure of a gas is",
+                                               "correctAnswer":  "bde",
+                                               "choices":  [
+                                                               "inversely proportional to its temperature",
+                                                               "directly proportional to the number of moles of the gas",
+                                                               "directly proportional to its volume",
+                                                               "directly proportional to its temperature",
+                                                               "inversely proportional to its volume"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6201248298041344,
+                         "orderBy":  " 9.3",
+                         "title":  "Gas Mixtures, Density, Partial Pressure",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  107023,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The equation\u003cbr\u003e\r\nP\u003csub\u003ea\u003c/sub\u003e = \u003ci\u003ex\u003c/i\u003e\u003csub\u003ea\u003c/sub\u003e P\u003csub\u003etotal\u003c/sub\u003e\u003cbr\u003e\r\nis a statement of",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "Avogadro\u0027s Law",
+                                                               "Boyle\u0027s Law",
+                                                               "Charles\u0027 Law",
+                                                               "Dalton\u0027s Law",
+                                                               "ideal gas law"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  107024,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The equation\u003cbr\u003e\r\nP\u003csub\u003etotal\u003c/sub\u003e = RT/V * (n\u003csub\u003ea\u003c/sub\u003e + n\u003csub\u003eb\u003c/sub\u003e + n\u003csub\u003ec\u003c/sub\u003e + ...)\u003cbr\u003e\r\nis a statement of",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "Avogadro\u0027s Law",
+                                                               "Boyle\u0027s Law",
+                                                               "Charles\u0027 Law",
+                                                               "Dalton\u0027s Law",
+                                                               "ideal gas law"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  107029,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Which gas has the highest density at 25 C?",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "H\u003csub\u003e2\u003c/sub\u003e",
+                                                               "He",
+                                                               "O\u003csub\u003e2\u003c/sub\u003e",
+                                                               "SF\u003csub\u003e6\u003c/sub\u003e",
+                                                               "Xe"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6208877049151488,
+                         "orderBy":  " 9.4",
+                         "title":  "Effusion and Diffusion of Gases",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  182009,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "For more than 50 years, uranium enrichment has been carried out at Oak Ridge National Laboratories by successive effusion of UF\u003csub\u003e6\u003c/sub\u003e gas. At each stage in this process, the lower pressure container becomes",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "slightly enriched in \u003csup\u003e235\u003c/sup\u003eU compared with \u003csup\u003e238\u003c/sup\u003eU.",
+                                                               "greatly enriched in \u003csup\u003e235\u003c/sup\u003eU compared with \u003csup\u003e238\u003c/sup\u003eU.",
+                                                               "greatly depleted in \u003csup\u003e235\u003c/sup\u003eU compared with \u003csup\u003e238\u003c/sup\u003eU.",
+                                                               "slightly depleted in \u003csup\u003e235\u003c/sup\u003eU compared with \u003csup\u003e238\u003c/sup\u003eU."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6212689654710272,
+                                               "type":  "NUMERIC",
+                                               "text":  "What is the ratio of the effusion rate of He compared with an unknown gas having a molar mass of #a/10# g/mol?",
+                                               "correctAnswer":  "sqrt(a/10/4.006)",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  3,
+                                               "parameterString":  "a 400:999",
+                                               "solution":  "Graham\u0027s Law states that the rate of effusion is inversely proportional to the square root of the molar mass.\u003cbr/\u003e\r\nRatio = (|He rate|Unk rate|) = ((|#a/10#|4.006|))\u003csup\u003e1/2\u003c/sup\u003e = #sqrt(a/10/4.006)#",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6265618279170048,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "In a mixture of gases, the _________ of individual gas molecules can affect how quickly they diffuse.",
+                                               "correctAnswer":  "mass",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6213897916252160,
+                         "orderBy":  " 9.5",
+                         "title":  "Kinetic Molecular Theory of Gases",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  107025,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The root mean square average molecular speed of a gas molecule is ",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "directly proportional to its molar mass.",
+                                                               "inversely proportional to its molar mass.",
+                                                               "directly proportional to the square root of its molar mass.",
+                                                               "inversely proportional to the square root of its molar mass.",
+                                                               "directly proportional to the square of its molar mass."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  159016,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "In a mixture of two different gases, the average molecular speed is",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "faster for the lighter gas than the heavier.",
+                                                               "faster for the heavier gas than the lighter.",
+                                                               "exactly the same for both gases.",
+                                                               "equal to 3/2 RT.",
+                                                               "proportional to the partial pressure of each gas."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  181015,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "According to the kinetic theory of gases, the average kinetic energy of a molecule of ideal gas is directly proportional to its",
+                                               "correctAnswer":  "temperature, absolute temperature, temperature in Kelvins, temperature in K, K",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6092690734710784,
+                         "orderBy":  " 9.6",
+                         "title":  "Non-ideal Gas Behavior",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  97015,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The main effect of attractive intermolecular forces between molecules is to cause the pressure of a real gas to be slightly",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "higher than predicted by the ideal gas law.",
+                                                               "lower than predicted by the ideal gas law."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  110021,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The van der Waals equation of state for a nonideal gas includes terms that correct for",
+                                               "correctAnswer":  "ad",
+                                               "choices":  [
+                                                               "the finite size of the molecules",
+                                                               "the finite mass of the molecules",
+                                                               "the angular momentum of the molecules",
+                                                               "the intermolecular forces between molecules",
+                                                               "the nonideal temperature of the molecules"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4864972541919232,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "At high _________, gas particles are close enough that the volume occupied by the gas molecules themselves is no longer negligible.",
+                                               "correctAnswer":  "pressure,density",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6208460974194688,
+                         "orderBy":  "10.1",
+                         "title":  "Intermolecular Forces",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93012,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Which of the following has the strongest intermolecular forces?",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "HI",
+                                                               "HBr",
+                                                               "HCl",
+                                                               "HF"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  112031,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Which of the following has the strongest intermolecular forces?",
+                                               "correctAnswer":  "e",
+                                               "choices":  [
+                                                               "He",
+                                                               "Ne",
+                                                               "Ar",
+                                                               "Kr",
+                                                               "Xe"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  161004,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "A liquid is a phase of matter that",
+                                               "correctAnswer":  "bc",
+                                               "choices":  [
+                                                               "has a definite shape",
+                                                               "adopts the shape of its container",
+                                                               "has a definite volume",
+                                                               "adopts the volume of its container",
+                                                               "has weak intermolecular forces"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6292693067497472,
+                         "orderBy":  "10.2",
+                         "title":  "Properties of Liquids",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93013,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Which of the following has the highest boiling point?",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "CH\u003csub\u003e4\u003c/sub\u003e",
+                                                               "SiH\u003csub\u003e4\u003c/sub\u003e",
+                                                               "GeH\u003csub\u003e4\u003c/sub\u003e",
+                                                               "SnH\u003csub\u003e4\u003c/sub\u003e"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  110024,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The equilibrium vapor pressure of a liquid",
+                                               "correctAnswer":  "ad",
+                                               "choices":  [
+                                                               "is always greater than zero",
+                                                               "is always less than zero",
+                                                               "increases with increasing surface area",
+                                                               "increases with increasing temperature",
+                                                               "decreases with increasing temperature"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  132025,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The enthalpy of vaporization of a substance, \u0026Delta;H\u003csub\u003evap\u003c/sub\u003e,",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "is always less than zero",
+                                                               "is always greater than zero",
+                                                               "may be greater than or less than zero",
+                                                               "increases with increasing surface area",
+                                                               "decreases with increasing surface area"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6302585719357440,
+                         "orderBy":  "10.3",
+                         "title":  "Phase Transitions",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  99013,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The phase transition from solid to liquid is called",
+                                               "correctAnswer":  "melting, fusion",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  99014,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The phase transition from solid to liquid is called",
+                                               "correctAnswer":  "melting",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  123015,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The phase transition from gas to liquid is called",
+                                               "correctAnswer":  "condensation",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6215572685062144,
+                         "orderBy":  "10.4",
+                         "title":  "Phase Diagrams",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  127024,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "When a pure liquid is confined to a closed vessel, the phase boundary between liquid and gas phases will disappear when it is heated above its",
+                                               "correctAnswer":  "critical",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "temperature.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  131036,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "An unusual feature of the pressure-temperature phase diagram for water is",
+                                               "correctAnswer":  "e",
+                                               "choices":  [
+                                                               "the sublimation curve has a negative temperature dependence",
+                                                               "the triple point lies at a pressure above 1 atm",
+                                                               "the boiling point decreases with increasing pressure",
+                                                               "the melting point increases with increasing pressure",
+                                                               "the melting point decreases with increasing pressure"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  132026,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "An unusual feature of the pressure-temperature phase diagram for carbon dioxide is",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "the sublimation curve has a negative temperature dependence",
+                                                               "the triple point lies at a pressure above 1 atm",
+                                                               "the boiling point decreases with increasing pressure",
+                                                               "the critical pressure is less than 1 atm",
+                                                               "the melting point decreases with increasing pressure"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6210707778961408,
+                         "orderBy":  "10.5",
+                         "title":  "Solid State of Matter",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  108011,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "A solid is a phase of matter that",
+                                               "correctAnswer":  "ac",
+                                               "choices":  [
+                                                               "has a definite shape",
+                                                               "adopts the shape of its container",
+                                                               "has a definite volume",
+                                                               "adopts the volume of its container",
+                                                               "has weak intermolecular forces"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  123017,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "If a solid material has no energy gap between its valence band and conduction band, then the material is classified as an electrical",
+                                               "correctAnswer":  "conductor",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  127026,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The regular arrangement of atoms and molecules in a solid is called the",
+                                               "correctAnswer":  "crystalline,crystal",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "lattice.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6274294232907776,
+                         "orderBy":  "10.6",
+                         "title":  "Lattice Structures of Crystalline Solids",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  122018,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The relationship between the angle of X-ray diffraction and the distance between adjacent molecular layers in a crystal is known as the",
+                                               "correctAnswer":  "Bragg, Bragg\u0027s, Bragg\u0027s Law",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "Equation.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  125026,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The structure of a crystalline solid can be deduced by analyzing an X-ray",
+                                               "correctAnswer":  "diffraction",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "pattern representing constructive and destructive interference from the planes of atoms in the crystal.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  127027,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "One of the highest-density crystal structures that can be achieved by an atomic solid is called the",
+                                               "correctAnswer":  "cubic,face-centered cubic,hexagonal",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "close-packed structure.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4855391842467840,
+                         "orderBy":  "10.7",
+                         "title":  "Semiconductors and Band Theory",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  129028,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "In a p-type semiconductor, the charge carriers in the material are",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "protons",
+                                                               "electrons",
+                                                               "neutrons",
+                                                               "holes",
+                                                               "ions"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  132027,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "In an n-type semiconductor, the charge carriers in the material are",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "protons",
+                                                               "electrons",
+                                                               "neutrons",
+                                                               "holes",
+                                                               "ions"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4825755225948160,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "When silicon is doped with a small amount of a Group 3A element like gallium, charge carriers move easily in the valence band. This material is called an",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "extrinsic p-type semiconductor.",
+                                                               "extrinsic n-type semiconductor.",
+                                                               "intrinsic semiconductor."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6210694273302528,
+                         "orderBy":  "11.1",
+                         "title":  "Dissolution Process",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93035,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "If the solvent-solute interactions are stronger than the average of the solvent-solvent and solute-solute interactions, then heat is evolved and the overall mixing process is said to be",
+                                               "correctAnswer":  "exothermic",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  112038,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The change in \u003ci\u003eentropy\u003c/i\u003e associated with mixing of any two substances to form a solution",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "is always positive",
+                                                               "is always negative",
+                                                               "is always zero",
+                                                               "may be positive or negative"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  141029,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Solutions that contain water as the solvent are called",
+                                               "correctAnswer":  "aqueous",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "solutions.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6223377445945344,
+                         "orderBy":  "11.2",
+                         "title":  "Solubility",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93019,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Increasing the temperature of a solution containing a dissolved gas such as oxygen usually",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "increases the solubility of the gas",
+                                                               "decreases the solubility of the gas",
+                                                               "makes no difference to the solubility of the gas"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  105036,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The solubility of most solids in water",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "increases with increasing temperature",
+                                                               "decreases with increasing temperature",
+                                                               "is not strongly dependent on temperature",
+                                                               "is independent of temperature",
+                                                               "cannot be determined"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  105038,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The molarity of a solution is equal to",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "the number of moles of solute in 1.0 L of solution",
+                                                               "the number of moles of solute in 1.0 kg of solvent",
+                                                               "the number of moles of solute divided by the total moles of solvent and solute",
+                                                               "the mass of solute divided by the total mass of solution x 10\u003csup\u003e6\u003c/sup\u003e",
+                                                               "the volume of solute divided by the total volume of solution x 10\u003csup\u003e6\u003c/sup\u003e"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6251122750128128,
+                         "orderBy":  "11.3",
+                         "title":  "Electrolytes",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  4899315297812480,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "A nonelectrolyte",
+                                               "correctAnswer":  "c",
+                                               "choices":  [
+                                                               "completely dissociates to ions when dissolved in water.",
+                                                               "only slightly dissociates to ions when dissolved in water.",
+                                                               "does not produce ions when dissolved in water."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6194074540572672,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Strong electrolytes dissociate completely in solution, whereas _________ electrolytes only partially dissociate.",
+                                               "correctAnswer":  "weak",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6207743530106880,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Sodium chloride (table salt) is a good example of a",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "strong electrolyte.",
+                                                               "weak electrolyte.",
+                                                               "nonelectrolyte."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6287401802006528,
+                         "orderBy":  "11.4",
+                         "title":  "Colligative Properties",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93026,
+                                               "type":  "NUMERIC",
+                                               "text":  "The expected van\u0027t Hoff factor for colligative properties in dilute aqueous solutions using NaCl as the solute is",
+                                               "correctAnswer":  "2",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  93027,
+                                               "type":  "NUMERIC",
+                                               "text":  "The expected van\u0027t Hoff factor for colligative properties in dilute aqueous solutions using CaSO\u003csub\u003e4\u003c/sub\u003e as the solute is",
+                                               "correctAnswer":  "2",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  138017,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Deviations from ideal behavior in thermodynamic systems is usually expressed by the use of a(n)",
+                                               "correctAnswer":  "activity coefficient",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  ", which modifies a measured partial pressure or concentration.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6219692095569920,
+                         "orderBy":  "11.5",
+                         "title":  "Colloids",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  124019,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "A mixture in which a finely-divided substance is dispersed in a solvent-like medium is called a",
+                                               "correctAnswer":  "colloid,colloidal dispersion,colloidal suspension,colloidal system",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ". Examples include milk, fog and smoke.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  164021,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "A collection of amphiphilic molecules oriented with their hydrophilic head groups on the outside and the hydrophobic tails on the inside of the cluster is called a",
+                                               "correctAnswer":  "micelle",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  187011,
+                                               "type":  "TRUE_FALSE",
+                                               "text":  "Natural soap is mostly sodium stearate, which works by surrounding and suspending dirt and grease particles with amphiphilic particles so that they can be washed away in water.",
+                                               "correctAnswer":  "true",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6317780642562048,
+                         "orderBy":  "12.1",
+                         "title":  "Chemical Reaction Rates",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  149018,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The forward rate of reaction depends on the concentrations of the",
+                                               "correctAnswer":  "reactants",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  167027,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "For the gas phase reaction\u003cbr\u003e2 NO\u003csub\u003e2\u003c/sub\u003e + F\u003csub\u003e2\u003c/sub\u003e \u0026rarr; 2 NO\u003csub\u003e2\u003c/sub\u003eF\u003cbr\u003ethe rate of reaction is defined as",
+                                               "correctAnswer":  "e",
+                                               "choices":  [
+                                                               "d[NO\u003csub\u003e2\u003c/sub\u003e]/dt",
+                                                               "2 d[NO\u003csub\u003e2\u003c/sub\u003e]/dt",
+                                                               "-2 d[NO\u003csub\u003e2\u003c/sub\u003e]/dt",
+                                                               "\u0026frac12; d[NO\u003csub\u003e2\u003c/sub\u003e]/dt",
+                                                               "-\u0026frac12; d[NO\u003csub\u003e2\u003c/sub\u003e]/dt"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  182007,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "For the reaction\u003cbr\u003e2 N\u003csub\u003e2\u003c/sub\u003eO\u003csub\u003e5\u003c/sub\u003e \u0026rarr; 4 NO\u003csub\u003e2\u003c/sub\u003e + O\u003csub\u003e2\u003c/sub\u003e\u003cbr\u003ethe reaction rate is defined as",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "- 0.5 d[N\u003csub\u003e2\u003c/sub\u003eO\u003csub\u003e5\u003c/sub\u003e]/dt",
+                                                               "0.25 d[NO\u003csub\u003e2\u003c/sub\u003e]/dt",
+                                                               "d[O\u003csub\u003e2\u003c/sub\u003e]/dt",
+                                                               "all of the above"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4918019830841344,
+                         "orderBy":  "12.2",
+                         "title":  "Arrhenius Equation",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  150017,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The Arrhenius Law uses temperatures expressed on which temperature scales?",
+                                               "correctAnswer":  "cd",
+                                               "choices":  [
+                                                               "Fahrenheit",
+                                                               "Celsius",
+                                                               "Kelvin",
+                                                               "Rankine",
+                                                               "any of the above"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  165013,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The Arrhenius Law gives the dependence of the rate constant on temperature expressed on the",
+                                               "correctAnswer":  "Kelvin,absolute",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "scale.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  171028,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The E\u003csub\u003ea\u003c/sub\u003e parameter in the Arrhenius law is known as the",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "equalization parameter.",
+                                                               "Arrhenius factor.",
+                                                               "Arrhenius energy.",
+                                                               "activation energy.",
+                                                               "exponential factor."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6207992688541696,
+                         "orderBy":  "12.3",
+                         "title":  "Rate Laws",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  107019,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The reaction\u003cbr\u003eNO + O\u003csub\u003e3\u003c/sub\u003e \u0026rarr; NO\u003csub\u003e2\u003c/sub\u003e + O\u003csub\u003e2\u003c/sub\u003e\u003cbr\u003e occurs as a single elementary reaction.  Which of the following statements is true?",
+                                               "correctAnswer":  "abe",
+                                               "choices":  [
+                                                               "The reaction is first order in NO.",
+                                                               "The reaction is first order in O\u003csub\u003e3\u003c/sub\u003e.",
+                                                               "The reaction is first order in NO\u003csub\u003e2\u003c/sub\u003e.",
+                                                               "The reaction is first order in O\u003csub\u003e2\u003c/sub\u003e.",
+                                                               "The reaction is second-order overall."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  111018,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "For the dimerization reaction of C\u003csub\u003e2\u003c/sub\u003eF\u003csub\u003e4\u003c/sub\u003e, a plot of the reciprocal of reactant concentration versus time gives a straight line.  What conclusion can be drawn from this observation?",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "The reaction is first order.",
+                                                               "The reaction is second order.",
+                                                               "The reaction is third order.",
+                                                               "The reaction follows the Arrhenius Law.",
+                                                               "No valid conclusions can be drawn from the observation."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  142036,
+                                               "type":  "NUMERIC",
+                                               "text":  "Suppose that a reaction is first order in A and second order in B and proceeds at a rate of #a#.0 M s\u003csup\u003e-1\u003c/sup\u003e.  If the concentration of B is doubled, the new rate of reaction will be",
+                                               "correctAnswer":  "a*4",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "M s\u003csup\u003e-1\u003c/sup\u003e.",
+                                               "parameterString":  "a 2:9",
+                                               "solution":  "The original rate is #a# M/s.  Doubling the concentration of B increases the rate by a factor of 2\u003csup\u003e2\u003c/sup\u003e = 4 to #a*4# M/s because the reaction is second-oder in [B].",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4796919972364288,
+                         "orderBy":  "12.4",
+                         "title":  "Integrated Rate Laws",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93037,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The integrated rate law predicts that for the first-order decomposition of N\u003csub\u003e2\u003c/sub\u003eO\u003csub\u003e5\u003c/sub\u003e, the concentration of reactant should",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "increase linearly with time.",
+                                                               "decrease linearly with time.",
+                                                               "increase exponentially with time.",
+                                                               "decrease exponentially with time."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  111019,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "For the reaction X \u0026rarr; products, whose rate law is given by\u003cbr\u003e\r\nRate = k [X]\u003cbr\u003e\r\nwhich of the following plots should give a straight line?",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "[X] versus time",
+                                                               "log[X] versus time",
+                                                               "1/[X] versus time",
+                                                               "[X] versus 1/time",
+                                                               "log[X] versus 1/time"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  123012,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The half life of a first order reaction is independent of the ",
+                                               "correctAnswer":  "concentration ",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "of reactants.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6274444422545408,
+                         "orderBy":  "12.5",
+                         "title":  "Collision Theory",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  138011,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "When two molecules react, the unstable entity at the maximum potential energy point along the reaction path is called the",
+                                               "correctAnswer":  "activated complex,transition state",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  138013,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "For most chemical reactions, the ",
+                                               "correctAnswer":  "activation energy,activation barrier, energy of activation",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " is a potential energy barrier that must be surmounted in order for the reactants to be transformed into products.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  164016,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "According to the collision theory of gas phase reactions, the steric or orientation factor, P,",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "must be a positive number less than one.",
+                                                               "must be any positive number.",
+                                                               "must be zero for any real reaction.",
+                                                               "must be a negative number.",
+                                                               "cannot be determined experimentally."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6214281644736512,
+                         "orderBy":  "12.6",
+                         "title":  "Reaction Mechanisms",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  92026,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "In order for a proposed reaction mechanism to be validated (not proven), the following two conditions must be met.",
+                                               "correctAnswer":  "ad",
+                                               "choices":  [
+                                                               "the rate law predicted by the mechanism must be consistent with experimentally observed rate laws",
+                                                               "the reaction must be reversible",
+                                                               "the reaction must be run under isothermal conditions",
+                                                               "the elementary steps in the mechanism must sum to the overall reaction",
+                                                               "the order of reaction for each reactant must be a whole number"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  93036,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Branching chain reactions can lead to a sudden growth in the number of reactive species, possibly causing a(n)",
+                                               "correctAnswer":  "explosion",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  93038,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "For the reaction: A \u0026rarr; B \u0026rarr; C \u003cbr\u003ethe steady state approximation can only be made if the rate from B to C is ",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "much faster than the rate from A to B.",
+                                                               "much slower than the rate from A to B.",
+                                                               "exactly the same as the rate from A to B.",
+                                                               "zero."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6297894860095488,
+                         "orderBy":  "12.7",
+                         "title":  "Catalysis",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  138012,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Enzymes increase chemical reaction rates by lowering the ",
+                                               "correctAnswer":  "activation energy, activation barrier",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "needed to begin the reaction.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  138015,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The place where a substrate molecule binds to an enzyme is called the",
+                                               "correctAnswer":  "active site",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  162023,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "A(n)",
+                                               "correctAnswer":  "heterogeneous,inhomogeneous",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "catalyst is one that is present as a distinct different phase from the reactants.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6240428013125632,
+                         "orderBy":  "13.1",
+                         "title":  "Chemical Equilibria",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  149020,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "When a system is at equilibrium, the reaction",
+                                               "correctAnswer":  "quotient,Q",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " is equal the equilibrium constant.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  169016,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The fundamental characteristics of equilibrium states are",
+                                               "correctAnswer":  "acde",
+                                               "choices":  [
+                                                               "They are reached through spontaneous processes.",
+                                                               "They are independent of temperature and pressure.",
+                                                               "They show a dynamic balance of forward and reverse processes.",
+                                                               "They are the same regardless of the direction of approach.",
+                                                               "They display no macroscopic evidence of change."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  181005,
+                                               "type":  "TRUE_FALSE",
+                                               "text":  "The value of K depends on the choice of starting concentrations for reactants or products.",
+                                               "correctAnswer":  "false",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6241789920411648,
+                         "orderBy":  "13.2",
+                         "title":  "Equilibrium Constants",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  109024,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The law of mass action implies which two of the following statements?",
+                                               "correctAnswer":  "ae",
+                                               "choices":  [
+                                                               "K is equal to the ratio of equilibrium concentrations of products and reactants.",
+                                                               "K depends on the absolute values of concentrations of products and reactants.",
+                                                               "K\u003csub\u003eC\u003c/sub\u003e is independent of temperature.",
+                                                               "all equilibrium constants are independent of temperature.",
+                                                               "K is independent of the initial concentrations or pressures of reactants and products."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  124017,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Exponents of the equilibrium concentrations in the law of mass action come from the",
+                                               "correctAnswer":  "coefficients,coefficient,stoichiometric coefficients,stoichiometric coefficient",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "in the balanced chemical equation.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  130011,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "If the magnitude of an equilibrium constant is small, we know that the reaction favors",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "formation of products",
+                                                               "the reverse reaction to form reactants.",
+                                                               "a state where concentrations of reactants and products are approximately equal.",
+                                                               "reaction rates that are fast.",
+                                                               "reaction rates that are slow."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6197733471289344,
+                         "orderBy":  "13.3",
+                         "title":  "Le Chatelier\u0027s Principle",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  108014,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which three of the following equilibrium systems would react to find a new equilibrium point if disturbed by a change in volume at constant temperature?",
+                                               "correctAnswer":  "acd",
+                                               "choices":  [
+                                                               "CaCO\u003csub\u003e3\u003c/sub\u003e(s) \u0026harr; CaO(s) + CO\u003csub\u003e2\u003c/sub\u003e(g)",
+                                                               "NO(g) + O\u003csub\u003e3\u003c/sub\u003e(g) \u0026harr; NO\u003csub\u003e2\u003c/sub\u003e(g) + O\u003csub\u003e2\u003c/sub\u003e(g)",
+                                                               "N\u003csub\u003e2\u003c/sub\u003e(g) + 3 H\u003csub\u003e2\u003c/sub\u003e(g) \u0026harr; 2 NH\u003csub\u003e3\u003c/sub\u003e(g)",
+                                                               "2 H\u003csub\u003e2\u003c/sub\u003e(g) + O\u003csub\u003e2\u003c/sub\u003e(g) \u0026harr; 2 H\u003csub\u003e2\u003c/sub\u003eO(l)",
+                                                               "C(graphite) \u0026harr; C(diamond)"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  127022,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Le Chatelier\u0027s Principle states that if a system at equilibrium is subjected to a stress or disturbance, the system will react in a way that tends to",
+                                               "correctAnswer":  "counteract,decrease,reduce,minimize,minimizes,balance",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "the stress or disturbance.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  144035,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "If one of the products is added to a system initially at equilibrium, then the reaction will proceed in the",
+                                               "correctAnswer":  "backward,reverse,left,reactants",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "direction in order to decrease Q so that it once again equals K.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6095696473620480,
+                         "orderBy":  "13.4",
+                         "title":  "Equilibrium Calculations",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  6205856026198016,
+                                               "type":  "NUMERIC",
+                                               "text":  "At #a/10#\u0026deg;C the equilibrium constant for dimerization of nitrogen dioxide is K\u003csub\u003eP\u003c/sub\u003e = #exp(-(-57200-(a/10+273.15)*(-175.8))/8.314/(a/10+273.15))#\u003cbr/\u003e\r\n2 NO\u003csub\u003e2\u003c/sub\u003e(g) \u0026lrhar; N\u003csub\u003e2\u003c/sub\u003eO\u003csub\u003e4\u003c/sub\u003e(g)\u003cbr/\u003e\r\nIf the equilibrium partial pressure of NO\u003csub\u003e2\u003c/sub\u003e is #b/1000# bar, what is the partial pressure of N\u003csub\u003e2\u003c/sub\u003eO\u003csub\u003e4\u003c/sub\u003e?",
+                                               "correctAnswer":  "exp(-(-57200-(a/10+273.15)*(-175.8))/8.314/(a/10+273.15))*b/1000*b/1000",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  3,
+                                               "tag":  "bar",
+                                               "parameterString":  "a 300:800 b 100:250",
+                                               "solution":  "K = (|P\u003csub\u003eN2O4\u003c/sub\u003e|(P\u003csub\u003eNO2\u003c/sub\u003e)\u003csup\u003e2\u003c/sup\u003e|)\u003cbr/\u003e\r\nP\u003csub\u003eN2O4\u003c/sub\u003e = K * (P\u003csub\u003eNO2\u003c/sub\u003e)\u003csup\u003e2\u003c/sup\u003e = #exp(-(-57200-(a/10+273.15)*(-175.8))/8.314/(a/10+273.15))# * (#b/1000#)\u003csup\u003e2\u003c/sup\u003e = #exp(-(-57200-(a/10+273.15)*(-175.8))/8.314/(a/10+273.15))*b/1000*b/1000# bar",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6212562483412992,
+                                               "type":  "NUMERIC",
+                                               "text":  "At #a/10#\u0026deg;C, the equilibrium vapor pressure of water is #0.0317*exp(5280*(3.354E-3 - 1/(a/10+273.15)))# bar. What is the value of the equilibrium constant for vaporization of water?",
+                                               "correctAnswer":  "0.0317*exp(5280*(3.354E-3-1/(a/10+273.15)))",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  3,
+                                               "parameterString":  "a 300:450",
+                                               "solution":  "H\u003csub\u003e2\u003c/sub\u003eO(l) \u0026lrhar; H\u003csub\u003e2\u003c/sub\u003eO(g)\u003cbr/\u003e\r\nK = (|P/1 bar|1|) = #0.0317*exp(5280*(3.354E-3 - 1/(a/10+273.15)))#",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6216742426116096,
+                                               "type":  "NUMERIC",
+                                               "text":  "At #a#\u0026deg;C bromine vapor partially dissociates to Br atoms:\u003cbr/\u003e\r\nBr\u003csub\u003e2\u003c/sub\u003e(g) \u0026lrhar; 2 Br(g)\u0026nbsp;\u0026nbsp;\u0026nbsp;\u0026nbsp;\u0026nbsp;K\u003csub\u003eP\u003c/sub\u003e = #exp((-192784+(a+273.15)*104.62)/8.314/(a+273.15))#\u003cbr/\u003e\r\nIf the equilibrium partial pressure of Br\u003csub\u003e2\u003c/sub\u003e(g) is #b/1000# bar, what is the partial pressure of Br(g)?",
+                                               "correctAnswer":  "sqrt(exp((-192784+(a+273.15)*104.62)/8.314/(a+273.15))*b/1000)",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  3,
+                                               "tag":  "bar",
+                                               "parameterString":  "a 500:750 b 200:500",
+                                               "solution":  "K\u003csub\u003eP\u003c/sub\u003e = (|P\u003csub\u003eBr\u003c/sub\u003e\u003csup\u003e2\u003c/sup\u003e|P\u003csub\u003eBr2\u003c/sub\u003e|) = #exp((-192784+(a+273.15)*104.62)/8.314/(a+273.15))#\u003cbr/\u003e\r\nP\u003csub\u003eBr\u003c/sub\u003e = (#b/1000# * #exp((-192784+(a+273.15)*104.62)/8.314/(a+273.15))#)\u003csup\u003e1/2\u003c/sup\u003e = #sqrt(exp((-192784+(a+273.15)*104.62)/8.314/(a+273.15))*b/1000)# bar",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6233404466528256,
+                         "orderBy":  "14.1",
+                         "title":  "Bronsted-Lowry Acids \u0026 Bases",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  96011,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "A strong acid, strong base or soluble salt will",
+                                               "correctAnswer":  "dissociate, ionize, dissolve",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "completely in aqueous solution.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  108012,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which of the following household items are bases?",
+                                               "correctAnswer":  "ac",
+                                               "choices":  [
+                                                               "ammonia",
+                                                               "vinegar",
+                                                               "lye",
+                                                               "orange juice",
+                                                               "vitamin C"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  122019,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Aqueous ammonia is a classic example of a",
+                                               "correctAnswer":  "Bronsted-Lowry,Bronsted",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " type of base because it can accept a proton to form NH\u003csub\u003e4\u003c/sub\u003e\u003csup\u003e+\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6204073799319552,
+                         "orderBy":  "14.2",
+                         "title":  "pH and pOH",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  142034,
+                                               "type":  "NUMERIC",
+                                               "text":  "If the concentration of OH\u003csup\u003e-\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e in aqueous solution at 25 C is 10\u003csup\u003e-10\u003c/sup\u003e M, then the pH is",
+                                               "correctAnswer":  "4",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  142035,
+                                               "type":  "NUMERIC",
+                                               "text":  "If the concentration of H\u003csub\u003e3\u003c/sub\u003eO\u003csup\u003e+\u003c/sup\u003e in aqueous solution is 10\u003csup\u003e-5\u003c/sup\u003e M, then the pH is",
+                                               "correctAnswer":  "5",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  142037,
+                                               "type":  "NUMERIC",
+                                               "text":  "If the concentration of H\u003csub\u003e3\u003c/sub\u003eO\u003csup\u003e+\u003c/sup\u003e in aqueous solution is 10\u003csup\u003e-9\u003c/sup\u003e M, then the pH is",
+                                               "correctAnswer":  "9",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6299653263327232,
+                         "orderBy":  "14.3",
+                         "title":  "Relative Strengths of Acids and Bases",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  97017,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Water is said to have a",
+                                               "correctAnswer":  "leveling,moderating",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " effect on strong acids such as HCl and HNO\u003csub\u003e3\u003c/sub\u003e because essentially all of the protons are transferred to water in the form of H\u003csub\u003e3\u003c/sub\u003eO\u003csup\u003e+\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  97018,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Water is said to have a",
+                                               "correctAnswer":  "leveling,moderating",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " effect on strong bases such as NaOH and NaNH\u003csub\u003e2\u003c/sub\u003e because they react almost completely with water to form stoichiometric concentrations of OH\u003csup\u003e-\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  130015,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "In the autoionization reaction of water, the conjugate acid of OH\u003csup\u003e-\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e is",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "H\u003csub\u003e3\u003c/sub\u003eO\u003csup\u003e+\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e",
+                                                               "H\u003csub\u003e2\u003c/sub\u003eO\u003ci\u003e(l)\u003c/i\u003e",
+                                                               "OH\u003csup\u003e-\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e",
+                                                               "pH",
+                                                               "K\u003csub\u003ew\u003c/sub\u003e"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  5920639025676288,
+                         "orderBy":  "14.4",
+                         "title":  "Hydrolysis of Salts",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  102011,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "When an acid and base react with each other to form water and a salt, this type of reaction is called a ",
+                                               "correctAnswer":  "neutralization,neutralizing",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "reaction.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  196015,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Hydrolysis is the reaction of a substance with",
+                                               "correctAnswer":  "water,H2O",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4921645302546432,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which two of the following aqueous solutions are neutral?",
+                                               "correctAnswer":  "bd",
+                                               "choices":  [
+                                                               "NH\u003csub\u003e4\u003c/sub\u003eNO\u003csub\u003e3\u003c/sub\u003e(\u003ci\u003eaq\u003c/i\u003e)",
+                                                               "CsI(\u003ci\u003eaq\u003c/i\u003e)",
+                                                               "Na\u003csub\u003e2\u003c/sub\u003eSO\u003csub\u003e4\u003c/sub\u003e(\u003ci\u003eaq\u003c/i\u003e)",
+                                                               "KNO\u003csub\u003e3\u003c/sub\u003e(\u003ci\u003eaq\u003c/i\u003e)",
+                                                               "KHCO\u003csub\u003e3\u003c/sub\u003e(\u003ci\u003eaq\u003c/i\u003e)"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4812274933432320,
+                         "orderBy":  "14.5",
+                         "title":  "Polyprotic Acids",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  150023,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "An acid that exhibits more than one equivalence point during a titration is called a",
+                                               "correctAnswer":  "polyprotic",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " acid.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6200360481325056,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The acid ionization constants for H\u003csub\u003e2\u003c/sub\u003eCO\u003csub\u003e3\u003c/sub\u003e are\u003cbr/\u003e\r\nK\u003csub\u003ea1\u003c/sub\u003e = 4.3\u0026times;10\u003csup\u003e-7\u003c/sup\u003e\u003cbr/\u003e\r\nK\u003csub\u003ea2\u003c/sub\u003e = 4.7\u0026times;10\u003csup\u003e-11\u003c/sup\u003e\u003cbr/\u003e\r\nOn this basis we can predict that a 0.1 M solution of NaHCO\u003csub\u003e3\u003c/sub\u003e will be",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "acidic",
+                                                               "basic",
+                                                               "neutral"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6239960815632384,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Polyprotic acids can donate more than one _________ ion per molecule.",
+                                               "correctAnswer":  "hydrogen",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4790358587736064,
+                         "orderBy":  "14.6",
+                         "title":  "Buffer Solutions",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  130019,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which two of the following mixtures would be considered buffer solutions?",
+                                               "correctAnswer":  "be",
+                                               "choices":  [
+                                                               "HCl + NaCl",
+                                                               "HF + NaF",
+                                                               "HNO\u003csub\u003e3\u003c/sub\u003e + NaNO\u003csub\u003e3\u003c/sub\u003e",
+                                                               "HCl + NaOH",
+                                                               "HCN + NaCN"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  142038,
+                                               "type":  "NUMERIC",
+                                               "text":  "Benzoic acid has a pK\u003csub\u003ea\u003c/sub\u003e of 4.2. In a buffer solution at pH = 5.2, the concentration of benzoate anion is approximately",
+                                               "correctAnswer":  "10",
+                                               "requiredPrecision":  0.5,
+                                               "significantFigures":  0,
+                                               "tag":  " times higher than unionized benzoic acid.",
+                                               "solution":  "The Henderson-Hasselbalch equation states that the pH of solution is related to the pKa of the acid by\u003cbr\u003e\r\npH = pKa + log([A]/[HA])",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  155013,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "To design an effective buffer solution, you should select an acid having a value of pK\u003csub\u003ea\u003c/sub\u003e close to the desired",
+                                               "correctAnswer":  "pH",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  " of the solution.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6286328244731904,
+                         "orderBy":  "14.7",
+                         "title":  "Acid-Base Titrations",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  139019,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Different indicators show color changes at different values of pH because they have different",
+                                               "correctAnswer":  "acid ionization,ionization,acid dissociation,Ka",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " constants.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  188006,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "An acid-base indicator is a __________ or a _________.",
+                                               "correctAnswer":  "c",
+                                               "choices":  [
+                                                               "strong acid, strong base",
+                                                               "salt, ionic compond",
+                                                               "weak acid, weak base",
+                                                               "polar molecule, charged particle"
+                                                           ],
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  195006,
+                                               "type":  "NUMERIC",
+                                               "text":  "A\u0026nbsp;#a*10# mL solution of aqueous hydrochloric acid is titrated with #0.1*b# M NaOH.  The equivalence point is reached after addition of #30*c# mL of the base.  What was the original concentration of the hydrochloric acid?",
+                                               "correctAnswer":  "30*c/1000*0.1*b/(a*10)*1000",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  3,
+                                               "tag":  "M",
+                                               "parameterString":  "a 4:8 b 4:8 c 2:4",
+                                               "solution":  "Moles of base added = #30*c# mL * (|1 L|1000 mL|) * #0.1*b# = #30*c/1000*0.1*b# mol\u003cbr/\u003e\r\nConcentration of acid = (|#30*c/1000*0.1*b# mol|#a*10# mL|) * (|1000 mL|1 L|) = #30*c/1000*0.1*b/(a*10)*1000# M",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6217052452290560,
+                         "orderBy":  "15.1",
+                         "title":  "Slightly Soluble Salts",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  92025,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "As a general rule, which of the following types of salts are \u003ci\u003einsoluble\u003c/i\u003e in aqueous solutions?",
+                                               "correctAnswer":  "ad",
+                                               "choices":  [
+                                                               "sulfides",
+                                                               "chlorides",
+                                                               "nitrates",
+                                                               "hydroxides",
+                                                               "fluorides"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  93016,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Increasing the temperature of a solution containing a slightly soluble salt usually",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "increases the solubility of the salt",
+                                                               "decreases the solubility of the salt",
+                                                               "makes no difference to the solubility of the salt"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  107017,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Solubility depends on which of the following factors?",
+                                               "correctAnswer":  "abe",
+                                               "choices":  [
+                                                               "temperature",
+                                                               "pressure",
+                                                               "humidity",
+                                                               "total volume",
+                                                               "type of solvent"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6288910543486976,
+                         "orderBy":  "15.2",
+                         "title":  "Lewis Acids and Bases ",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  97020,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Boron trifluoride is a classic example of a",
+                                               "correctAnswer":  "Lewis",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " acid because it can form a bond by accepting a lone pair of electrons from a base.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  108015,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "During the formation of a coordination compound, a Lewis base donates a pair of electrons to a Lewis acid. The resulting bond is classified as a",
+                                               "correctAnswer":  "ac",
+                                               "choices":  [
+                                                               "dative bond",
+                                                               "halogen bond",
+                                                               "coordinate covalent bond",
+                                                               "alkali bond",
+                                                               "hydrogen bond"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  163019,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The Lewis definition of an \u003ci\u003eacid\u003c/i\u003e is",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "a substance that accepts lone-pair electrons.",
+                                                               "a substance that can donate a hydrogen ion.",
+                                                               "a substance that donates lone-pair electrons.",
+                                                               "a substance that increases [H\u003csub\u003e3\u003c/sub\u003eO\u003csup\u003e+\u003c/sup\u003e] in water.",
+                                                               "a substance that can accept a hydrogen ion."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4890037195374592,
+                         "orderBy":  "15.3",
+                         "title":  "Coupled Equilibria",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93014,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Adding strong acid to a solution of barium sulfate will have what effect on its solubility in aqueous solution?",
+                                               "correctAnswer":  "c",
+                                               "choices":  [
+                                                               "greatly increase",
+                                                               "greatly decrease",
+                                                               "very little change",
+                                                               "slightly increase",
+                                                               "slightly decrease"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  93015,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Adding a strong acid to a solution of magnesium carbonate will have which effect on its solubility in aqueous solution?",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "greatly increase",
+                                                               "slightly increase",
+                                                               "very little change",
+                                                               "slightly decrease",
+                                                               "greatly decrease"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  93020,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "What is the effect of adding a soluble salt to a solution of insoluble salt if the two salts share a common ion?",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "the solubility of the insoluble salt decreases.",
+                                                               "the solubility of the insoluble salt increases.",
+                                                               "the soluble salt becomes insoluble.",
+                                                               "the insoluble salt becomes soluble.",
+                                                               "there is no effect on solubility of either salt."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6246374747668480,
+                         "orderBy":  "15.4",
+                         "title":  "Formation of Complex Ions",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93039,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The equilibrium constant for binding of a metal ion to several ligands in a coordination complex is given the special name",
+                                               "correctAnswer":  "formation",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "constant.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  139018,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "When a metal-ligand bond is formed in a coordination complex, the metal acts as a Lewis",
+                                               "correctAnswer":  "acid",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  164014,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "When Ag\u003csup\u003e+\u003c/sup\u003e\u003ci\u003e(aq)\u003c/i\u003e ions form a coordination complex with ammonia molecules, the local structure around the central atom (disregarding the H atoms) is",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "linear",
+                                                               "bent",
+                                                               "triangular",
+                                                               "planar",
+                                                               "tetrahedral"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4892278379773952,
+                         "orderBy":  "16.1",
+                         "title":  "Reaction Spontaneity",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  178002,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The term \"spontaneous thermodynamic process\" means that",
+                                               "correctAnswer":  "cde",
+                                               "choices":  [
+                                                               "the process starts immediately",
+                                                               "the process is fast",
+                                                               "there exists a driving force for change",
+                                                               "it is associated with an increase of total entropy",
+                                                               "it is irreversible"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  180006,
+                                               "type":  "TRUE_FALSE",
+                                               "text":  "A process cannot be spontaneous if the \u003ci\u003eentropy\u003c/i\u003e change for the system is negative.",
+                                               "correctAnswer":  "false",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  180008,
+                                               "type":  "TRUE_FALSE",
+                                               "text":  "A process cannot be spontaneous if the \u003ci\u003eenthalpy\u003c/i\u003e change for the system is positive.",
+                                               "correctAnswer":  "false",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6247226862469120,
+                         "orderBy":  "16.2",
+                         "title":  "Entropy",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  92024,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The molar \u003ci\u003eentropy\u003c/i\u003e of any substance",
+                                               "correctAnswer":  "ad",
+                                               "choices":  [
+                                                               "is always greater than or equal to zero.",
+                                                               "may be positive or negative depending on the enthalpy of formation.",
+                                                               "is always zero at absolute zero.",
+                                                               "is zero only for the pure perfectly crystalline substance at 0 K.",
+                                                               "can take on any value because the entropy scale has no absolute reference point."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  97014,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which of the following statements must be true for any gas dissolved in aqueous solution?\u003cbr/\u003e\r\nA(\u003ci\u003eg\u003c/i\u003e) \u0026lrhar; A(\u003ci\u003eaq\u003c/i\u003e)",
+                                               "correctAnswer":  "ac",
+                                               "choices":  [
+                                                               "\u0026Delta;H \u003c 0",
+                                                               "\u0026Delta;H \u003e 0",
+                                                               "\u0026Delta;S \u003c 0",
+                                                               "\u0026Delta;S \u003e 0",
+                                                               "\u0026Delta;G \u003c 0"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  140021,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Who has \"S = k log W\" carved on his tombstone?",
+                                               "correctAnswer":  "Boltzmann,Ludwig Boltzmann",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6198423417520128,
+                         "orderBy":  "16.3",
+                         "title":  "2nd \u0026 3rd Laws of Thermodynamics",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  98019,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Spontaneous contractions of gases or precipitation of dissolved solutes do not occur in nature in the absence of external forces because they are associated with",
+                                               "correctAnswer":  "e",
+                                               "choices":  [
+                                                               "increasing temperature.",
+                                                               "increasing total entropy.",
+                                                               "constant pressure.",
+                                                               "decreasing temperature.",
+                                                               "decreasing total entropy."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  106013,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which of the following are valid statements of the Second Law of thermodynamics?",
+                                               "correctAnswer":  "abcde",
+                                               "choices":  [
+                                                               "No device can transfer heat from a cold reservoir to a warmer one without a net expenditure of work.",
+                                                               "No device can convert heat into work with 100% efficiency",
+                                                               "Heat always flows spontaneously from hot to cold.",
+                                                               "Work is always required to refrigerate a body",
+                                                               "You can\u0027t win; the best you can do is to break even."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  127038,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "At absolute zero, the \u003ci\u003eentropy\u003c/i\u003e of any pure substance in its equilibrium state must be",
+                                               "correctAnswer":  "c",
+                                               "choices":  [
+                                                               "positive.",
+                                                               "negative.",
+                                                               "zero.",
+                                                               "equal to its enthalpy of formation."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4871822104854528,
+                         "orderBy":  "16.4",
+                         "title":  "Free Energy",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93034,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The formation of water from hydrogen and oxygen has a negative change in entropy under standard conditions. However, the reaction is spontaneous because it is highly",
+                                               "correctAnswer":  "exothermic",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  109030,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The most general definition of the Gibbs free energy state function is",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "G = H + TS",
+                                                               "G = H - TS",
+                                                               "G = E + PV",
+                                                               "G = E - PV",
+                                                               "G = H - PT"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  110028,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which three statements are true about a chemical reaction at equilibrium?",
+                                               "correctAnswer":  "ade",
+                                               "choices":  [
+                                                               "it is a balance between two opposing reactions",
+                                                               "the reaction is irreversible reaction",
+                                                               "the reaction is spontaneous",
+                                                               "the change in Gibb\u0027s free energy is zero",
+                                                               "the rates of the forward and reverse reactions are equal"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6320980946845696,
+                         "orderBy":  "16.5",
+                         "title":  "Carnot Engine",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  107015,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "A Carnot engine cycle includes which of the following processes?",
+                                               "correctAnswer":  "abde",
+                                               "choices":  [
+                                                               "adiabatic expansion",
+                                                               "isothermal expansion",
+                                                               "irreversible expansion",
+                                                               "isothermal compression",
+                                                               "adiabatic compression"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  182011,
+                                               "type":  "TRUE_FALSE",
+                                               "text":  "The thermodynamic efficiency of a Carnot engine depends only on the temperatures of the heat reservoirs.",
+                                               "correctAnswer":  "true",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  193018,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The thermodynamic efficiency of any general cyclic process of gas expansion and compression can be analyzed by considering it to consist of a series of",
+                                               "correctAnswer":  "Carnot",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "engine cycles.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4877114796408832,
+                         "orderBy":  "17.1",
+                         "title":  "Oxidation-Reduction Reactions",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93028,
+                                               "type":  "NUMERIC",
+                                               "text":  "What is the formal oxidation state of magnesium in Mg(OH)\u003csub\u003e2\u003c/sub\u003e?",
+                                               "correctAnswer":  "2",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  94018,
+                                               "type":  "NUMERIC",
+                                               "text":  "What is the formal oxidation state of nitrogen in NO\u003csub\u003e3\u003c/sub\u003e\u003csup\u003e-\u003c/sup\u003e(aq)?",
+                                               "correctAnswer":  "5",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  144042,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "All electrochemistry occurs as a result of",
+                                               "correctAnswer":  "redox,oxidation-reduction",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "reactions.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6285938879102976,
+                         "orderBy":  "17.2",
+                         "title":  "Galvanic Cells",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  106014,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The conventional shorthand method for describing galvanic cells has the following characteristics:",
+                                               "correctAnswer":  "abcde",
+                                               "choices":  [
+                                                               "anode is on the left; cathode on the right",
+                                                               "electron flow is from left to right",
+                                                               "phase boundaries are shown as single vertical lines",
+                                                               "location of a salt bridge is indicated by double vertical lines",
+                                                               "electric current flows from right to left"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  111012,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The electrode where reduction takes place is called the",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "standard calomel electrode",
+                                                               "cathode",
+                                                               "anode",
+                                                               "reference electrode",
+                                                               "salt bridge"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  112036,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The process of oxidation occurs at which point in a voltaic cell?",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "Anode",
+                                                               "Cathode",
+                                                               "Diode",
+                                                               "Solution"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6276504127799296,
+                         "orderBy":  "17.3",
+                         "title":  "Electrode and Cell Potentials",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  111015,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "A type of electrode that is designed to be sensitive to concentrations of specific ions other than H\u003csub\u003e3\u003c/sub\u003eO\u003csup\u003e+\u003c/sup\u003e is called a(n)",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "pH electrode",
+                                                               "ion-selective electrode",
+                                                               "calomel electrode",
+                                                               "glass electrode",
+                                                               "working electrode"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  177006,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "When writing a half-reaction as an oxidation, what is the appropriate thing to do to the half-cell reduction potential?",
+                                               "correctAnswer":  "c",
+                                               "choices":  [
+                                                               "multiply by the number of electrons transferred in the reaction",
+                                                               "divide by the number of electrons transferred in the reaction",
+                                                               "change the sign to obtain the half-cell oxidation potential",
+                                                               "multiply by -nF to obtain the Gibbs Free Energy change",
+                                                               "apply  the opposing potential to make the reaction reversible"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  183009,
+                                               "type":  "TRUE_FALSE",
+                                               "text":  "An ion-selective electrode is only sensitive to concentrations of H+.",
+                                               "correctAnswer":  "false",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6306798948057088,
+                         "orderBy":  "17.4",
+                         "title":  "Potential, Free Energy \u0026 Equilibrium",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  98020,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The dependence of electrochemical cell potential on the concentrations and partial pressures of reactants and products can be calulated using the",
+                                               "correctAnswer":  "Nernst",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "equation.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  111016,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The standard half-cell reduction potential for the conversion of hydronium ions to hydrogen gas is 0.00 volts (by definition). In \u003ci\u003epure\u003c/i\u003e water (with no added acid), the reduction potential observed in the presence of 1 bar H\u003csub\u003e2\u003c/sub\u003e(g) is",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "0.00 v, by definition",
+                                                               "less than 0.00 v",
+                                                               "between 0.00 v and 1.00 v",
+                                                               "exactly 1.00 v",
+                                                               "undetermined (not enough information given)"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  144048,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "If the electrochemical potential for a cell is negative, the overall electrochemical reaction is",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "spontaneous in the forward direction.",
+                                                               "spontaneous in the reverse direction.",
+                                                               "at equilibrium."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6288897037828096,
+                         "orderBy":  "17.5",
+                         "title":  "Batteries \u0026 Fuel Cells",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  111013,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "On any common battery such as an alkaline cell, the + terminal corresponds to the ",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "anode",
+                                                               "cathode",
+                                                               "salt bridge",
+                                                               "reference electrode",
+                                                               "emitter-collector"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  111014,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Alkaline dry cells have steadier voltages compared with ordinary zinc-carbon (Leclanche) cells because",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "the presence of strong base keeps the pH high in the anode",
+                                                               "none of the reacting species depends on concentration",
+                                                               "the presence of strong base keeps the pH high in the cathode",
+                                                               "strong base helps to keep NH\u003csub\u003e3\u003c/sub\u003e dissolved in the aqueous phase",
+                                                               "strong base has a tendency to dissolve the paper salt bridge"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  140012,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "A closed galvanic system designed to store a particular amount of chemical energy for conversion to electrical energy is called a(n)",
+                                               "correctAnswer":  "battery,voltaic cell",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6248506578173952,
+                         "orderBy":  "17.6",
+                         "title":  "Corrosion",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  106016,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which factors can accelerate the corrosion of metals?",
+                                               "correctAnswer":  "abce",
+                                               "choices":  [
+                                                               "presence of dissolved salt",
+                                                               "higher acidity",
+                                                               "presence of dissolved carbon dioxide",
+                                                               "presence of a thin layer of metal oxide",
+                                                               "presence of sulfur oxides from pollution"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  110029,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Some of the methods for inhibiting corrosion of metals include",
+                                               "correctAnswer":  "ade",
+                                               "choices":  [
+                                                               "painting",
+                                                               "salt wash",
+                                                               "sacrificial cathode",
+                                                               "sacrificial anode",
+                                                               "passivation"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  127021,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The process by which iron and other metals undergo electrochemical degradation is called",
+                                               "correctAnswer":  "corrosion,rusting",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6310733758857216,
+                         "orderBy":  "17.7",
+                         "title":  "Electrolysis and Disproportionation",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  142032,
+                                               "type":  "NUMERIC",
+                                               "text":  "The decomposition potential of water under standard conditions is ",
+                                               "correctAnswer":  "1.229",
+                                               "requiredPrecision":  1,
+                                               "significantFigures":  0,
+                                               "tag":  "V",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  183006,
+                                               "type":  "TRUE_FALSE",
+                                               "text":  "Most metal oxides are thermodynamically unstable with respect to disproportionation to pure metal and oxygen.",
+                                               "correctAnswer":  "false",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  183007,
+                                               "type":  "TRUE_FALSE",
+                                               "text":  "The overall decomposition potential of water to hydrogen and oxygen depends on the pH of the solution containing the electrodes.",
+                                               "correctAnswer":  "false",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6237299666321408,
+                         "orderBy":  "18.1",
+                         "title":  "Classification of Elements",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  4819164833513472,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The combination of a metal and a nonmetal usually produces a",
+                                               "correctAnswer":  "salt",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "which consists of cations and anions.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6096225106919424,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Representative elements that are classified as metals usually form which two of the following?",
+                                               "correctAnswer":  "ac",
+                                               "choices":  [
+                                                               "cations",
+                                                               "anions",
+                                                               "ionic compounds",
+                                                               "molecular compounds",
+                                                               "colloids"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6199982926856192,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Inner transition metals are defined by location in the Periodic Table where",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "s orbitals are filling",
+                                                               "p orbitals are filling",
+                                                               "d orbitals are filling",
+                                                               "f orbitals are filling"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6279451062566912,
+                         "orderBy":  "18.2",
+                         "title":  "Representative Metals",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  4867279604154368,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "This representative metal, _________, is often used in street lamps, causing them to emit a characteristic yellow light.",
+                                               "correctAnswer":  "sodium",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4882294006874112,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The most common method of producing tin metal is by high-temperature reduction of SnO\u003csub\u003e2\u003c/sub\u003e(s) by",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "C(s).",
+                                                               "Si(s).",
+                                                               "Zn(s).",
+                                                               "CO(g)",
+                                                               "VO\u003csub\u003e2\u003c/sub\u003e(g)"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4901249106837504,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The most common method of producing magnesium metal is by high-temperature reduction of MgO(s) by",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "C(s).",
+                                                               "Si(s).",
+                                                               "Zn(s).",
+                                                               "CO(g)",
+                                                               "VO\u003csub\u003e2\u003c/sub\u003e(g)"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4859649714552832,
+                         "orderBy":  "18.3",
+                         "title":  "Metalloids",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  4879651876110336,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Arsenic is a metalloid that has historically been used as a poison and in _________ production.",
+                                               "correctAnswer":  "pesticide",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4895117904445440,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The element _________, known for its role in LED technology, is considered a metalloid.",
+                                               "correctAnswer":  "gallium",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6194025204023296,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Unlike metals, the crystal structures of metalloids are characterized by",
+                                               "correctAnswer":  "covalent",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "bonds between adjacent atoms, forming a network solid.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6312652183175168,
+                         "orderBy":  "18.4",
+                         "title":  "Nonmetals",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  4796051814088704,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "A common nonmetal element that is used in the production of computer chips due to its semiconducting properties is _________.",
+                                               "correctAnswer":  "silicon",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4857419100585984,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Unlike metals, which form closely packed arrays, the nonmetal elements form",
+                                               "correctAnswer":  "covalent",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "bonds, and many exist as individual molecules.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6203187240894464,
+                                               "type":  "NUMERIC",
+                                               "text":  "Within any row of the Periodic Table, the element that is the strongest oxidizing agent is in Group ___.",
+                                               "correctAnswer":  "17",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6307670289547264,
+                         "orderBy":  "18.5",
+                         "title":  "Compounds of Hydrogen",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  4875369781395456,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "A compound of hydrogen and nitrogen that is useful as monopropellant in spacecraft maneuvering thrusters is named",
+                                               "correctAnswer":  "hydrazine",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ". It is reasonably stable, but highly toxic.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4914875360346112,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which two of the following hydrogen halides have the most commercial significance for manufacturing other compounds and materials?",
+                                               "correctAnswer":  "ab",
+                                               "choices":  [
+                                                               "HF",
+                                                               "HCl",
+                                                               "HBr",
+                                                               "HI"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5945706031874048,
+                                               "type":  "NUMERIC",
+                                               "text":  "Many hydrocarbons react with water to form a mixture of CO and H\u003csub\u003e2\u003c/sub\u003e called \u003ci\u003ewater gas\u003c/i\u003e. How many moles of H\u003csub\u003e2\u003c/sub\u003e are produced in this type of reaction per mole of C\u003csub\u003e#a#\u003c/sub\u003eH\u003csub\u003e#2*a+2#\u003c/sub\u003e?",
+                                               "correctAnswer":  "2*a+1",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "mol H\u003csub\u003e2\u003c/sub\u003e",
+                                               "parameterString":  "a 2:6",
+                                               "solution":  "The balanced reaction is\u003cbr/\u003e\r\nC\u003csub\u003e#a#\u003c/sub\u003eH\u003csub\u003e#2*a+2#\u003c/sub\u003e + #a# H\u003csub\u003e2\u003c/sub\u003eO \u0026rarr; #a# CO + #2*a+1# H\u003csub\u003e2\u003c/sub\u003e",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4923420097118208,
+                         "orderBy":  "18.6",
+                         "title":  "Carbonates",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  4852380499968000,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Metal carbonates like CaCO\u003csub\u003e3\u003c/sub\u003e are",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "very weak bases.",
+                                                               "moderately strong bases.",
+                                                               "moderately strong acids.",
+                                                               "very weak acids.",
+                                                               "neutral salts."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6212070990413824,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The mineral _________ is a carbonate compound that often forms stalactites and stalagmites in caves.",
+                                               "correctAnswer":  "calcite",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6232476837478400,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The two metal carbonates that are used commercially in the largest quantities are",
+                                               "correctAnswer":  "ab",
+                                               "choices":  [
+                                                               "Na\u003csub\u003e2\u003c/sub\u003eCO\u003csub\u003e3\u003c/sub\u003e",
+                                                               "CaCO\u003csub\u003e3\u003c/sub\u003e",
+                                                               "PbCO\u003csub\u003e3\u003c/sub\u003e",
+                                                               "MgCO\u003csub\u003e3\u003c/sub\u003e",
+                                                               "K\u003csub\u003e2\u003c/sub\u003eCO\u003csub\u003e3\u003c/sub\u003e"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6220980401209344,
+                         "orderBy":  "18.7a",
+                         "title":  "Compounds of Nitrogen",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  1114126,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Acid rain is caused in part by oxides of nitrogen from vehicle emissions, which combine with water and air to form",
+                                               "correctAnswer":  "nitric,nitrous",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "acid.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4872200968732672,
+                                               "type":  "NUMERIC",
+                                               "text":  "The lowest (most negative) oxidation state of nitrogen is",
+                                               "correctAnswer":  "-3",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6203143419592704,
+                                               "type":  "NUMERIC",
+                                               "text":  "The highest (most positive) oxidation state of nitrogen is",
+                                               "correctAnswer":  "5",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6248829908680704,
+                         "orderBy":  "18.7b",
+                         "title":  "Compounds of Phosphorus",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  4839748061626368,
+                                               "type":  "NUMERIC",
+                                               "text":  "The oxidation state of phosphorus in one of its most common forms, P\u003csub\u003e4\u003c/sub\u003eO\u003csub\u003e10\u003c/sub\u003e, is",
+                                               "correctAnswer":  "5",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4917675892670464,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "_________ acid is a triprotic acid used in soft drinks to add a tangy flavor.",
+                                               "correctAnswer":  "Phosphoric",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6215068127854592,
+                                               "type":  "NUMERIC",
+                                               "text":  "The oxidation state of phosphorus in diphosphorus tetrahydride, is",
+                                               "correctAnswer":  "-2",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6320163812540416,
+                         "orderBy":  "18.7c",
+                         "title":  "Compounds of Oxygen",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  4612836483661824,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Oxygen and compounds of oxygen are found in abundance in all of the following \u003ci\u003eexcept\u003c/i\u003e",
+                                               "correctAnswer":  "e",
+                                               "choices":  [
+                                                               "the earth\u0027s crust",
+                                                               "the earth\u0027s hydrosphere",
+                                                               "the earth\u0027s atmosphere",
+                                                               "the earth\u0027s plants and animals",
+                                                               "the earth\u0027s core"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4911403416944640,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The layer of atmospheric ozone that helps to protect us from harmful UV light from the sun is located primarily in the",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "troposphere",
+                                                               "stratosphere",
+                                                               "thermosphere",
+                                                               "mesosphere",
+                                                               "exosphere"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5932836430807040,
+                                               "type":  "TRUE_FALSE",
+                                               "text":  "Oxygen reacts at room temperature with nearly all other elements except the noble gases and halogens.",
+                                               "correctAnswer":  "true",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6241321634758656,
+                         "orderBy":  "18.7d",
+                         "title":  "Compounds of Sulfur",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  1112109,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Acid rain is caused in part by oxides of sulfur from coal-fired electrical generators, which combine with water and air to form",
+                                               "correctAnswer":  "sulfuric,sulfurous",
+                                               "requiredPrecision":  2,
+                                               "significantFigures":  0,
+                                               "tag":  "acid.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6196795525038080,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which three characteristics of sulfur are true?",
+                                               "correctAnswer":  "abc",
+                                               "choices":  [
+                                                               "The most stable elemental form is S\u003csub\u003e8\u003c/sub\u003e.",
+                                                               "It exhibits oxidation states as high as 6+.",
+                                                               "The element exists in several different allotropic forms.",
+                                                               "Sulfur will oxidize more electronegative nonmetals.",
+                                                               "In oxyacids, sulfur exhibits an oxidation state of 2-."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6249987599237120,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "A compound often used in rubber vulcanization is zinc ________.",
+                                               "correctAnswer":  "sulfide",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6283504186294272,
+                         "orderBy":  "18.8",
+                         "title":  "Halogens",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  5947772313796608,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Which of the halogens is most abundant in nature?",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "F",
+                                                               "Cl",
+                                                               "Br",
+                                                               "I",
+                                                               "At"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6208192735608832,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "________ is a halogen known for its use in disinfecting wounds and as an antiseptic.",
+                                               "correctAnswer":  "Iodine",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6212279419011072,
+                                               "type":  "TRUE_FALSE",
+                                               "text":  "All of the halogens occur in seawater as halide ions.",
+                                               "correctAnswer":  "true",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6210029241237504,
+                         "orderBy":  "18.9",
+                         "title":  "Noble Gases",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  6255511418175488,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "All of the following are important applications of helium \u003ci\u003eexcept\u003c/i\u003e",
+                                               "correctAnswer":  "e",
+                                               "choices":  [
+                                                               "filling balloons and lighter-than-air aircraft",
+                                                               "liquid helium is used as a coolant in cryogenic research",
+                                                               "mixtures with oxygen in scuba tanks to avoid nitrogen narcosis",
+                                                               "inert atmosphere for welding air-sensitive metals",
+                                                               "creating a red glow from electric discharge in signage"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6285534381211648,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which four of the noble gases are produced by fractional distillation of liquid air?",
+                                               "correctAnswer":  "bcde",
+                                               "choices":  [
+                                                               "He",
+                                                               "Ne",
+                                                               "Ar",
+                                                               "Kr",
+                                                               "Xe"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6295437434159104,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Although the noble gases are highly unreactive, it is now known that Xe and Kr can form stable compounds with",
+                                               "correctAnswer":  "fluorine,F",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6196656441131008,
+                         "orderBy":  "19.1",
+                         "title":  "Transition Metals and Compounds",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  131025,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The 5th period transition metal having the highest binding energy (melting point) is",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "Cadmium",
+                                                               "Molybdenum",
+                                                               "Palladium",
+                                                               "Zirconium",
+                                                               "Strontium"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  139020,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Oxides of transition metals that are in high oxidation states tend to be more",
+                                               "correctAnswer":  "acidic",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "than the corresponding oxides in lower oxidation states.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  142028,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The 6th period transition metal having the lowest binding energy (melting point) is",
+                                               "correctAnswer":  "c",
+                                               "choices":  [
+                                                               "Iron",
+                                                               "Osmium",
+                                                               "Mercury",
+                                                               "Tungsten",
+                                                               "Tantalum"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6322084870881280,
+                         "orderBy":  "19.2",
+                         "title":  "Coordination Chemistry",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  111024,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Which of the following is the NOT a step for naming coordination complexes?",
+                                               "correctAnswer":  "e",
+                                               "choices":  [
+                                                               "Name ligands in alphabetical order",
+                                                               "Count the oxidation state of the metal ",
+                                                               "Name the counter ions",
+                                                               "Add prefix such as di, tri, tetra, etc",
+                                                               "Counting the total number of carbon contained within the complex"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  127025,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The",
+                                               "correctAnswer":  "Crystal Field",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "theory is a simple model used to describe the energies of coordination complexes that is based on an ionic description of metal-ligand bonds.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  131026,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The geometrical isomer of [Co(NH\u003csub\u003e3\u003c/sub\u003e)\u003csub\u003e4\u003c/sub\u003eCl\u003csub\u003e2\u003c/sub\u003e in which the chlorine ligands are on opposite sides of the metal atom is called",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "\u003ci\u003ecis\u003c/i\u003e",
+                                                               "\u003ci\u003etrans\u003c/i\u003e",
+                                                               "\u003ci\u003ebis\u003c/i\u003e",
+                                                               "\u003ci\u003egauche\u003c/i\u003e",
+                                                               "\u003ci\u003esyn\u003c/i\u003e"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6247043655270400,
+                         "orderBy":  "19.3",
+                         "title":  "Properties of Coordination Compounds",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  125022,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Substances that are repelled by a non-uniform magnetic field are called ",
+                                               "correctAnswer":  "diamagnetic",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  145037,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Substances that are attracted by a non-uniform magnetic field are called ",
+                                               "correctAnswer":  "paramagnetic,ferromagnetic",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  148021,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Isomers that have the same number and type of atoms, the same number of bonds, but with different spatial arrangements which make non-superimposable mirror images (cannot be rotated to be exactly the same) are called",
+                                               "correctAnswer":  "optical ",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "isomers.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  5413381544869888,
+                         "orderBy":  "19.4",
+                         "title":  "Metallurgy",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  6193753089114112,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "In metallurgy, a process that separates a metal from its ore is called _______.",
+                                               "correctAnswer":  "reduction",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6210149185486848,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The process of heating ore in the presence of air to remove impurities is called _________.",
+                                               "correctAnswer":  "roasting",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6275869105717248,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "An alloy is a mixture of two or more _________.",
+                                               "correctAnswer":  "metals",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6264875151523840,
+                         "orderBy":  "20.1",
+                         "title":  "Hydrocarbons",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  96017,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Butane and isobutane are said to be structural",
+                                               "correctAnswer":  "isomers",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "because they have the same number and type of atoms but different atomic connectivities.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  108019,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The special properties of carbon that make it especially suited to the chemistry of biology are:",
+                                               "correctAnswer":  "acd",
+                                               "choices":  [
+                                                               "tendency to form as many as 4 covalent bonds",
+                                                               "high electrochemical potential",
+                                                               "ability to form double and triple bonds",
+                                                               "tendency to catenate (form chains and rings)",
+                                                               "low ionization energy"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  108020,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The following are examples of aliphatic hydrocarbons",
+                                               "correctAnswer":  "acd",
+                                               "choices":  [
+                                                               "ethane",
+                                                               "benzene",
+                                                               "ethyne",
+                                                               "propene",
+                                                               "naphthalene"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6227543379673088,
+                         "orderBy":  "20.2",
+                         "title":  "Alcohols \u0026 Ethers",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  93032,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "What is the IUPAC name for the organic alcohol most likely to be found in vodka?",
+                                               "correctAnswer":  "ethanol",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  93033,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The functional group R-O-R is indicative of a general class of compounds called",
+                                               "correctAnswer":  "ethers",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  111025,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The correct molecular formula for propanol is",
+                                               "correctAnswer":  "e",
+                                               "choices":  [
+                                                               "CH\u003csub\u003e3\u003c/sub\u003eCHCH\u003csub\u003e2\u003c/sub\u003e",
+                                                               "CH\u003csub\u003e3\u003c/sub\u003eCH\u003csub\u003e2\u003c/sub\u003eCH\u003csub\u003e3\u003c/sub\u003e",
+                                                               "CH\u003csub\u003e3\u003c/sub\u003eCOCH\u003csub\u003e3\u003c/sub\u003e",
+                                                               "CH\u003csub\u003e3\u003c/sub\u003eCOOH",
+                                                               "CH\u003csub\u003e3\u003c/sub\u003eCH\u003csub\u003e2\u003c/sub\u003eCH\u003csub\u003e2\u003c/sub\u003eOH"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6202581700837376,
+                         "orderBy":  "20.3",
+                         "title":  "Aldehydes, Ketones, Acids \u0026 Esters",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  92035,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The correct molecular formula for acetic acid is",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "CH\u003csub\u003e3\u003c/sub\u003eCHCH\u003csub\u003e2\u003c/sub\u003e",
+                                                               "CH\u003csub\u003e3\u003c/sub\u003eCH\u003csub\u003e2\u003c/sub\u003eCH\u003csub\u003e3\u003c/sub\u003e",
+                                                               "CH\u003csub\u003e3\u003c/sub\u003eCOCH\u003csub\u003e3\u003c/sub\u003e",
+                                                               "CH\u003csub\u003e3\u003c/sub\u003eCOOH",
+                                                               "CH\u003csub\u003e3\u003c/sub\u003eCH\u003csub\u003e2\u003c/sub\u003eCH\u003csub\u003e2\u003c/sub\u003eOH"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  93031,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The functional group R-COOR is indicative of a general class of compounds called",
+                                               "correctAnswer":  "esters",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  165015,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Mild oxidation of a secondary alcohol will produce the corresponding",
+                                               "correctAnswer":  "ketone",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  ".",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4880409438978048,
+                         "orderBy":  "20.4",
+                         "title":  "Amines and Amides",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  92036,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "A functional group of the form R-NH\u003csub\u003e2\u003c/sub\u003e is what type of compound?",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "aldehyde",
+                                                               "phenol",
+                                                               "amide",
+                                                               "amine",
+                                                               "alcohol"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5829810366709760,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Which general classification is appropriate for molecules that contain bonds between nitrogen and carbon?",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "amine",
+                                                               "amide",
+                                                               "amino acid",
+                                                               "ammonia",
+                                                               "carbohydrate"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6219437619544064,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Which general classification is appropriate for molecules that contain a bond between nitrogen and the carbon atom of a carbonyl group?",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "amine",
+                                                               "amide",
+                                                               "amino acid",
+                                                               "ammonia",
+                                                               "carbohydrate"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6275936437927936,
+                         "orderBy":  "20.5",
+                         "title":  "Stereoisomers",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  92030,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The two different types of stereoisomers are",
+                                               "correctAnswer":  "ad",
+                                               "choices":  [
+                                                               "geometric isomers",
+                                                               "structural isomers",
+                                                               "rotational isomers",
+                                                               "optical isomers"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  97019,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "If a crystal composed of one of two optical isomers rotates the plane of polarized light in a counterclockwise direction, it is called to be the",
+                                               "correctAnswer":  "levorotatory,levorotary,L",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "isomer.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  125021,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "If a crystal composed of one of two optical isomers rotates the plane of polarized light in a clockwise direction, it is called to be the",
+                                               "correctAnswer":  "dextrorotatory,dextrorotary,D",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "isomer.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6250721658011648,
+                         "orderBy":  "20.6",
+                         "title":  "Polymers and Plastics",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  92037,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "During polymer growth, the reaction of a free radical center with a secondary or tertiary hydrogen atom on another polymer is called",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "propagation",
+                                                               "termination",
+                                                               "initiation",
+                                                               "branching",
+                                                               "condensation"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  92038,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Polyfunctional monomer units can be used to make very strong synthetic polymers by joining chains together in a process called",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "polyfunctionalization",
+                                                               "nonlinear chain growth",
+                                                               "synthetic networking",
+                                                               "cross-linking",
+                                                               "formaldization"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  92039,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Polyethylene synthesized using the Ziegler catalyst typically consists of long unbranched chains with large crystalline regions. This type of polyethylene is called",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "low-density polyethylene (LDPE)",
+                                                               "linear low-density polyethylene (LLDPE)",
+                                                               "medium density polyethylene (MDPE)",
+                                                               "high-density polyethylene (HDPE)",
+                                                               "high yield polyethylene (HYPE)"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6234239149801472,
+                         "orderBy":  "21.1",
+                         "title":  "Nuclear Structure \u0026 Stability",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  97013,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Due to the binding energy of the nucleus and electrons, the mass of every atom is",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "slightly less than the masses of its constituent protons, neutrons and electrons.",
+                                                               "slightly greater than the masses of its constituent protons, neutrons and electrons.",
+                                                               "exactly the same as the masses of its constituent protons, neutrons and electrons."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  148020,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "A positron is an elementary particle that has the same mass as an electron but ",
+                                               "correctAnswer":  "opposite,positive",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "charge.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  170019,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Heavy nuclides that have a N/Z ratio higher than the valley of stability tend to decay by",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "alpha emission",
+                                                               "beta emission",
+                                                               "positron emission",
+                                                               "electron capture",
+                                                               "nuclear fusion"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6282230577496064,
+                         "orderBy":  "21.2",
+                         "title":  "Nuclear Equations",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  109021,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Alpha radiation, when compared with other types of naturally occurring radioactivity, has the",
+                                               "correctAnswer":  "ade",
+                                               "choices":  [
+                                                               "highest ionizing power",
+                                                               "lowest ionizing power",
+                                                               "highest penetrating power",
+                                                               "lowest penetrating power",
+                                                               "highest mass"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  162022,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "An alpha particle is identical to the nucleus of a",
+                                               "correctAnswer":  "helium,helium-4,He,4 He",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "atom.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  174006,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Compared with other types of naturally occurring radioactivity, beta particles",
+                                               "correctAnswer":  "bce",
+                                               "choices":  [
+                                                               "have higher ionizing power than alpha particles",
+                                                               "have higher penetrating power than alpha particles",
+                                                               "have higher ionizing power than gamma rays",
+                                                               "have higher penetrating power than gamma rays",
+                                                               "have higher mass than gamma rays"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6207769937444864,
+                         "orderBy":  "21.3",
+                         "title":  "Radioactive Decay",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  92031,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "When an atom undergoes alpha decay, ",
+                                               "correctAnswer":  "ad",
+                                               "choices":  [
+                                                               "the atomic mass decreases by 4",
+                                                               "the atomic mass increases by 1",
+                                                               "the atomic mass in unchanged",
+                                                               "the atomic number decreases by 2",
+                                                               "the atomic number increases by 1"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  92041,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "When \u003csup\u003e30\u003c/sup\u003eP undergoes positron emission, the decay products are",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "\u003csup\u003e31\u003c/sup\u003eS + e\u003csup\u003e+\u003c/sup\u003e",
+                                                               "\u003csup\u003e30\u003c/sup\u003eS + e\u003csup\u003e+\u003c/sup\u003e",
+                                                               "\u003csup\u003e31\u003c/sup\u003eP + e\u003csup\u003e+\u003c/sup\u003e",
+                                                               "\u003csup\u003e30\u003c/sup\u003eSi + e\u003csup\u003e+\u003c/sup\u003e",
+                                                               "\u003csup\u003e31\u003c/sup\u003eSi + e\u003csup\u003e+\u003c/sup\u003e"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  102012,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Beta decay occurs when a",
+                                               "correctAnswer":  "neutron",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  "is converted to a proton, and the resulting beta particle is ejected from the nucleus.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6272984720867328,
+                         "orderBy":  "21.4",
+                         "title":  "Nuclear Fission \u0026 Fusion",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  107021,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Technetium is a synthetic element that can be made by electron capture from the element",
+                                               "correctAnswer":  "d",
+                                               "choices":  [
+                                                               "Nb",
+                                                               "Mo",
+                                                               "Tc",
+                                                               "Ru",
+                                                               "Rh"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  185009,
+                                               "type":  "TRUE_FALSE",
+                                               "text":  "Nuclear fission is a process when two nuclei of an atom combine to form a heavier atom, while nuclear fusion is the splitting of a nucleus into two lighter particles.",
+                                               "correctAnswer":  "false",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  5409177409421312,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The fusion of two light nuclei results in one heavier one whose mass is",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "slightly greater than the two reactants.",
+                                                               "slightly less than the two reactants.",
+                                                               "exactly the same as the two reactants."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4910898874941440,
+                         "orderBy":  "21.5",
+                         "title":  "Uses of Radioisotopes",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  99012,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The second highest source of background radiation is from harnessing nuclear chemistry for use in",
+                                               "correctAnswer":  "medicine,dentistry,medical prodecures",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4760621208043520,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Radioisotopes are used in medicine both as tracers and as treatment to destroy cancer cells. However, for treatment",
+                                               "correctAnswer":  "a",
+                                               "choices":  [
+                                                               "the doses are typically much higher.",
+                                                               "the half-lives are typically much longer.",
+                                                               "the doses are tyically much lower.",
+                                                               "the half-lives are typically much shorter.",
+                                                               "the radioisotopes emit only gamma rays."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6193615068200960,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "Radioactive sodium-24 is sometimes used to prepare saline solutions to",
+                                               "correctAnswer":  "c",
+                                               "choices":  [
+                                                               "image the extent of heart tissue damage.",
+                                                               "treat thyroid conditions such as Grave\u0027s disease.",
+                                                               "locate obstructions to blood flow.",
+                                                               "detect narcotics in passenger luggage.",
+                                                               "kill cancer cells using radiation therapy."
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6201897593077760,
+                         "orderBy":  "21.6",
+                         "title":  "Biological Effects of Radiation",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  107012,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which three of the following devices are designed to detect radioactive decay particles and rays:",
+                                               "correctAnswer":  "abd",
+                                               "choices":  [
+                                                               "scintillation counter",
+                                                               "Geiger-Muller counter",
+                                                               "electron capture counter",
+                                                               "film-badge dosimeter",
+                                                               "nanometric ventilator"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  true,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  149013,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Roughly 50% of background radiation is due to the naturally occurring isotope",
+                                               "correctAnswer":  "Radon-222, radon 222, Rn222, Rn-222, 222 radon",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4809283769466880,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Chronic exposure to low-level radiation can increase the risk of developing ________, a disease characterized by the uncontrolled division of abnormal cells.",
+                                               "correctAnswer":  "cancer",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6265011819511808,
+                         "orderBy":  "22.1",
+                         "title":  "Lipids",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  6214818561523712,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "_________ is a process that artificially saturates unsaturated fats and results in trans fats.",
+                                               "correctAnswer":  "Hydrogenation",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6237478137888768,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Lipids that are solid at room temperature are usually called ________.",
+                                               "correctAnswer":  "fats",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6266287629271040,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "_________ fatty acids have one or more double bonds in their hydrocarbon chain.",
+                                               "correctAnswer":  "Unsaturated",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6279649168719872,
+                         "orderBy":  "22.2",
+                         "title":  "Carbohydrates",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  4855944520663040,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "In the human body, the enzyme _________ is responsible for breaking down starch into simpler sugars.",
+                                               "correctAnswer":  "amylase",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  4909287083343872,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Cellulose, a polysaccharide found in plant cell walls, is primarily composed of long chains of _________.",
+                                               "correctAnswer":  "glucose",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6224713092431872,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "_________ is a common example of a monosaccharide, also known as an essential simple sugar.",
+                                               "correctAnswer":  "Glucose",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6289045214986240,
+                         "orderBy":  "22.3",
+                         "title":  "Amino Acids and Proteins",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  6001858043969536,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "_______ bonds are the special type of covalent bond that links amino acids in a protein.",
+                                               "correctAnswer":  "Peptide",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6208970619617280,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The primary structure of a protein is determined by its sequence of __________.",
+                                               "correctAnswer":  "amino acids",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6250631802388480,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The three-dimensional shape of a protein is known as its ________ structure.",
+                                               "correctAnswer":  "tertiary",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  4907738065010688,
+                         "orderBy":  "22.4",
+                         "title":  "Nucleic Acids",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  6205689533038592,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "DNA is structured in a double _________.",
+                                               "correctAnswer":  "helix",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6209786000703488,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "In DNA, adenine pairs with _________.",
+                                               "correctAnswer":  "thymine",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6210264285577216,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The sugar found in RNA is called _________.",
+                                               "correctAnswer":  "ribose",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6301372593209344,
+                         "orderBy":  "23.1",
+                         "title":  "Chemical Separations",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  4818341740150784,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "In chromatography, substances are separated based on their different affinities to the mobile and ________ phases.",
+                                               "correctAnswer":  "stationary",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6223994012565504,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The process of separating a pure compound from a solution by evaporating the solvent is known as ________.",
+                                               "correctAnswer":  "recrystallization",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  6234266173440000,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "Distillation is a method used to separate components based on differences in their ________ points.",
+                                               "correctAnswer":  "boiling",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6027554100346880,
+                         "orderBy":  "24.1",
+                         "title":  "Environmental Chemistry",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  131024,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The temperature inversion in the stratosphere creates a large stable airmass that strongly resists",
+                                               "correctAnswer":  "b",
+                                               "choices":  [
+                                                               "cloud formation",
+                                                               "vertical mixing",
+                                                               "lateral movement by the jet stream",
+                                                               "horizontal mixing",
+                                                               "absorption of UV light"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  142027,
+                                               "type":  "MULTIPLE_CHOICE",
+                                               "text":  "The atmosphere is divided roughly into four regions at different altitudes, based mainly on characteristic variations of",
+                                               "correctAnswer":  "c",
+                                               "choices":  [
+                                                               "clouds",
+                                                               "absorption",
+                                                               "temperature",
+                                                               "pressure",
+                                                               "humidity"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  145034,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "The atmosphere shields the earth from solar radiation at wavelengths shorter than 200 nm mainly by photodissociation of",
+                                               "correctAnswer":  "oxygen,O2",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " molecules in the thermosphere.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     },
+                     {
+                         "id":  6264087344578560,
+                         "orderBy":  "25.1",
+                         "title":  "Molecular Spectroscopy",
+                         "public":  true,
+                         "questions":  [
+                                           {
+                                               "id":  92027,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "Which of the following involves absorption of high-frequency visible, ultraviolet and/or X-ray radiation?",
+                                               "correctAnswer":  "ad",
+                                               "choices":  [
+                                                               "electronic spectroscopy",
+                                                               "rotational spectroscopy",
+                                                               "nuclear magnetic resonance",
+                                                               "photoelectron spectroscopy",
+                                                               "vibrational spectroscopy"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  102020,
+                                               "type":  "FILL_IN_WORD",
+                                               "text":  "If the PES fine structure shows that the vibrational frequency of the ion is about the same as the parent neutral, then it is likely that the electron was removed from a(n)",
+                                               "correctAnswer":  "nonbonding,non-bonding",
+                                               "choices":  "",
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "tag":  " molecular orbital.",
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           },
+                                           {
+                                               "id":  106012,
+                                               "type":  "SELECT_MULTIPLE",
+                                               "text":  "The intensity of an absorption line in a rotational spectrum depends on",
+                                               "correctAnswer":  "abcd",
+                                               "choices":  [
+                                                               "molar extinction coefficient",
+                                                               "population ratio of the inital and final states",
+                                                               "temperature",
+                                                               "strength of the transition",
+                                                               "phase of the moon"
+                                                           ],
+                                               "requiredPrecision":  0,
+                                               "significantFigures":  0,
+                                               "scrambleChoices":  false,
+                                               "strictSpelling":  false
+                                           }
+                                       ]
+                     }
+                 ]
+}


### PR DESCRIPTION
## Summary
- Add a public `/example-questions` servlet that serves 3 example questions from a standalone sample library
- Add grouped, fuzzy-searchable concept browsing with pill controls and per-question hints
- Add `sampleQuestionLibrary.json` with 156 concepts and 3 questions per concept
- Link the example questions page from the homepage

## Verification
- `mvn -q -DskipTests package`
- Checked `/example-questions` locally returns 200 and renders 3 questions
- Audited JSON: 156 concepts, 468 questions, 0 concepts without exactly 3 questions